### PR TITLE
Separate Canberra from Melbourne and Sydney

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -1,0 +1,16 @@
+# syntax=docker/dockerfile:1
+FROM node:12-alpine
+EXPOSE 7070/tcp
+RUN apk add --no-cache npm python3 make g++
+WORKDIR /app
+COPY . .
+RUN mkdir /config
+VOLUME /config
+WORKDIR /app/src
+RUN mv example.config.json /config/config.json
+RUN mv example.servers.json /config/servers.json
+RUN npm install
+WORKDIR /app
+RUN echo "cp /config/config.json /app/src/config.json && cp /config/servers.json /app/src/servers.json &&  npm start" > startup.sh
+RUN chmod +x startup.sh
+ENTRYPOINT "/app/startup.sh"

--- a/src/services/account/timezones.json
+++ b/src/services/account/timezones.json
@@ -1122,11 +1122,18 @@
                 "order": "9"
             },
             {
+                "area": "Australia/Camberra",
+                "language": "pt",
+                "name": "Camberra",
+                "utc_offset": "39600",
+                "order": "10"
+            },
+            {
                 "area": "Pacific/Norfolk",
                 "language": "pt",
                 "name": "Ilha Norfolk",
                 "utc_offset": "39600",
-                "order": "10"
+                "order": "11"
             }
         ],
         "ru": [


### PR DESCRIPTION
Canberra does not follow daylight savings time when Melbourne and Sydney do, they should be separated to avoid issues with the time becoming desynchronized during daylight savings time.