### PR TITLE
docker: Allow option to autogenerate keys

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,12 +1,27 @@
 #!/bin/sh
 
 # this doesnt check game server specific certs, only static file paths
-files='config.json certs/nex/datastore/secret.key certs/service/account/secret.key certs/service/account/aes.key certs/service/account/private.pem certs/service/account/public.pem'
+files='config.json'
 
 for file in $files; do
     if [ ! -f $file ]; then
         echo "$PWD/$file file does not exist. Please mount and try again."
         exit 1
+    fi
+done
+
+# check for keys
+keys='certs/nex/datastore/secret.key certs/service/account/secret.key certs/service/account/aes.key certs/service/account/private.pem certs/service/account/public.pem'
+for file in $keys; do
+    if [ ! -f "$file" ]; then
+        if [ x"${GENERATE_NEW_KEYS}" = "x" ]; then
+            echo "$PWD/$file file does not exist. Please mount and try again."
+            exit 1
+        else
+            echo "$PWD/$file file does not exist. Generating a temporary one"
+            node generate-keys.js nex datastore
+            node generate-keys.js account
+        fi
     fi
 done
 


### PR DESCRIPTION
While this isn't optimal for prod, for dev environments it can be very helpful to opt-in for things to Just Work.

Off by default, can opt in via an environment variable.