### PR TITLE
Check for undefined on latest_webhook_timestamp

### DIFF
--- a/src/services/grpc/api/get-user-data.ts
+++ b/src/services/grpc/api/get-user-data.ts
@@ -38,7 +38,7 @@ export async function getUserData(_request: Empty, context: CallContext & Authen
 				priceId: pnid.connections.stripe.price_id,
 				tierLevel: pnid.connections.stripe.tier_level,
 				tierName: pnid.connections.stripe.tier_name,
-				latestWebhookTimestamp: BigInt(pnid.connections.stripe.latest_webhook_timestamp)
+				latestWebhookTimestamp: BigInt(pnid.connections.stripe.latest_webhook_timestamp ?? 0)
 			}
 		},
 		marketingFlag: pnid.flags.marketing

--- a/src/services/grpc/api/update-user-data.ts
+++ b/src/services/grpc/api/update-user-data.ts
@@ -40,7 +40,7 @@ export async function updateUserData(_request: UpdateUserDataRequest, context: C
 				priceId: pnid.connections.stripe.price_id,
 				tierLevel: pnid.connections.stripe.tier_level,
 				tierName: pnid.connections.stripe.tier_name,
-				latestWebhookTimestamp: BigInt(pnid.connections.stripe.latest_webhook_timestamp)
+				latestWebhookTimestamp: BigInt(pnid.connections.stripe.latest_webhook_timestamp ?? 0)
 			}
 		},
 		marketingFlag: pnid.flags.marketing


### PR DESCRIPTION
Not all accounts are guaranteed to have this field, so we have to check if it exists. If it doesn't, just set the value to 0.