### PR TITLE
Better handling of system transfered devices

### DIFF
--- a/src/middleware/nasc.ts
+++ b/src/middleware/nasc.ts
@@ -122,8 +122,8 @@ async function NASCMiddleware(request: express.Request, response: express.Respon
 			// * If a user performs a system transfer from
 			// * a console to another using a Nintendo account
 			// * during the transfer and both consoles have
-			// * a Pretendo account, the devices will be swapped
-			// * since we check it using the LFCS.
+			// * a Pretendo account, the new device won't have
+			// * the user's PID.
 			// *
 			// * So, the linked PIDs won't have the user's PID
 			// * anymore.
@@ -132,6 +132,16 @@ async function NASCMiddleware(request: express.Request, response: express.Respon
 
 				await device.save();
 			}
+		}
+
+		if (device.serial !== serialNumber) {
+			response.status(200).send(nascError('102').toString());
+			return;
+		}
+
+		if (device.mac_hash !== macAddressHash) {
+			response.status(200).send(nascError('102').toString());
+			return;
 		}
 	}
 
@@ -142,10 +152,6 @@ async function NASCMiddleware(request: express.Request, response: express.Respon
 	// *
 	// * This would make the Pretendo account to not have
 	// * a device on the database.
-	// *
-	// * TODO: With this change, now multiple devices can
-	// * have the same serial number and MAC address.
-	// * Do we want this? If not, are there other solutions?
 	if (!device && pid) {
 		device = new Device({
 			model,

--- a/src/middleware/nasc.ts
+++ b/src/middleware/nasc.ts
@@ -95,12 +95,16 @@ async function NASCMiddleware(request: express.Request, response: express.Respon
 		return;
 	}
 
-	const nexAccount: HydratedNEXAccountDocument | null = await NEXAccount.findOne({ pid });
+	let nexAccount: HydratedNEXAccountDocument | null = null;
+	if (pid) {
+		nexAccount = await NEXAccount.findOne({ pid });
 
-	if (!nexAccount || nexAccount.access_level < 0) {
-		response.status(200).send(nascError('102').toString());
-		return;
+		if (!nexAccount || nexAccount.access_level < 0) {
+			response.status(200).send(nascError('102').toString());
+			return;
+		}
 	}
+
 
 	let device: HydratedDeviceDocument | null = await Device.findOne({
 		fcdcert_hash: fcdcertHash,
@@ -164,7 +168,7 @@ async function NASCMiddleware(request: express.Request, response: express.Respon
 
 			try {
 				// Create new NEX account
-				const nexAccount: HydratedNEXAccountDocument = new NEXAccount({
+				nexAccount = new NEXAccount({
 					device_type: '3ds',
 					password
 				});

--- a/src/middleware/nasc.ts
+++ b/src/middleware/nasc.ts
@@ -124,14 +124,9 @@ async function NASCMiddleware(request: express.Request, response: express.Respon
 			// * So, the linked PIDs won't have the user's PID
 			// * anymore.
 			if (!linkedPIDs.includes(pid)) {
-				const session: mongoose.ClientSession = await databaseConnection().startSession();
-				await session.startTransaction();
-
 				device.linked_pids.push(pid);
 
-				await device.save({ session });
-
-				await session.commitTransaction();
+				await device.save();
 			}
 		}
 	}
@@ -148,9 +143,6 @@ async function NASCMiddleware(request: express.Request, response: express.Respon
 	// * have the same serial number and MAC address.
 	// * Do we want this? If not, are there other solutions?
 	if (!device && pid) {
-		const session: mongoose.ClientSession = await databaseConnection().startSession();
-		await session.startTransaction();
-
 		device = new Device({
 			model,
 			serial: serialNumber,
@@ -160,9 +152,7 @@ async function NASCMiddleware(request: express.Request, response: express.Respon
 			linked_pids: [pid]
 		});
 
-		await device.save({ session });
-
-		await session.commitTransaction();
+		await device.save();
 	}
 
 	if (titleID === '0004013000003202') {


### PR DESCRIPTION
If a user performs a system transfer, we can't guarantee the validity of the linked PIDs to a device, not this device's existance on the database. Add them to the database if necessary.

The NEX account check has been moved to the top so that we can verify that the PID exists on the database before adding it to a device.