### PR TITLE
services: Add CBVC endpoint

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -15,6 +15,7 @@ import { fullUrl, getValueFromHeaders } from '@/util';
 import { LOG_INFO, LOG_SUCCESS, LOG_WARN } from '@/logger';
 
 import conntest from '@/services/conntest';
+import cbvc from '@/services/cbvc';
 import nnid from '@/services/nnid';
 import nasc from '@/services/nasc';
 import datastore from '@/services/datastore';
@@ -39,6 +40,7 @@ app.use(xmlparser);
 
 // import the servers into one
 app.use(conntest);
+app.use(cbvc);
 app.use(nnid);
 app.use(nasc);
 app.use(datastore);

--- a/src/services/cbvc/index.ts
+++ b/src/services/cbvc/index.ts
@@ -1,0 +1,31 @@
+// handles CBVC (CTR Browser Version Check?) endpoints
+
+import express from 'express';
+import subdomain from 'express-subdomain';
+import { LOG_INFO } from '@/logger';
+
+// Router to handle the subdomain restriction
+const cbvc: express.Router = express.Router();
+
+// Setup route
+LOG_INFO('[cbvc] Applying imported routes');
+cbvc.get('/:consoleType/:unknown/:region', (request: express.Request, response: express.Response): void => {
+	response.set('Content-Type', 'text/plain');
+
+	// * https://www.3dbrew.org/wiki/Internet_Browser#Forced_system-update
+	// * The returned value is a number which the Internet Browser then compares
+	// * with its own version number. If the version number isn't higher than the
+	// * returned value, it will show a console update message.
+	// *
+	// * Return 0 and allow any browser to connect.
+	response.send('0');
+});
+
+// Main router for endpoints
+const router: express.Router = express.Router();
+
+// Create subdomains
+LOG_INFO('[cbvc] Creating \'cbvc\' subdomain');
+router.use(subdomain('cbvc.cdn', cbvc));
+
+export default router;


### PR DESCRIPTION
This allows any version of the 3DS internet browser to connect using Pretendo.

The `:unknown` section seems to represent an incrementing "version" number, but I wasn't able to relate this number with the version shown in the browser info.

I added this endpoint on the account server as it was very simple.