### PR TITLE
Fix 3DS profile updates causing an unhandledRejection

### DIFF
--- a/src/services/nnid/routes/people.ts
+++ b/src/services/nnid/routes/people.ts
@@ -582,7 +582,9 @@ router.put('/@me', async (request: express.Request, response: express.Response):
 	const language: string = person.language ? person.language : pnid.language;
 	let timezoneName: string = person.tz_name ? person.tz_name : pnid.timezone.name;
 
-	// Fix for 3DS sending empty person.tz_name, which is interpreted as an empty object
+	// * Fix for 3DS sending empty person.tz_name, which is interpreted as an empty object
+	// TODO - See if there's a cleaner way to do this?
+
 	if (typeof timezoneName === 'object' && Object.keys(timezoneName).length === 0) {
 		timezoneName = pnid.timezone.name;
 	}

--- a/src/services/nnid/routes/people.ts
+++ b/src/services/nnid/routes/people.ts
@@ -580,7 +580,13 @@ router.put('/@me', async (request: express.Request, response: express.Response):
 	const region: number = person.region ? person.region : pnid.region;
 	const countryCode: string = person.country ? person.country : pnid.country;
 	const language: string = person.language ? person.language : pnid.language;
-	const timezoneName: string = person.tz_name ? person.tz_name : pnid.timezone.name;
+	let timezoneName: string = person.tz_name ? person.tz_name : pnid.timezone.name;
+
+	// Fix for 3DS sending empty person.tz_name, which is interpreted as an empty object
+	if (typeof timezoneName === 'object' && Object.keys(timezoneName).length === 0) {
+		timezoneName = pnid.timezone.name;
+	}
+
 	const marketingFlag: boolean = person.marketing_flag ? person.marketing_flag === 'Y' : pnid.flags.marketing;
 	const offDeviceFlag: boolean = person.off_device_flag ? person.off_device_flag === 'Y' : pnid.flags.off_device;
 


### PR DESCRIPTION
For example, when attempting to change the email address. The 3DS sends an empty person.tz_name, which is interpreted as an empty object. This additional error handling is necessary in this case because empty objects are truthy.

I noticed that a few people were having issues changing their email addresses in #support, and I was able to reproduce this issue. I tested this fix locally and it does work, although only checking timezoneName for emptiness is a little messy.