### PR TITLE
Fix NASC datetime field

### DIFF
--- a/src/services/nasc/routes/ac.ts
+++ b/src/services/nasc/routes/ac.ts
@@ -1,5 +1,5 @@
 import express from 'express';
-import { nintendoBase64Encode, nintendoBase64Decode, nascError, generateToken } from '@/util';
+import { nintendoBase64Encode, nintendoBase64Decode, nascDateTime, nascError, generateToken } from '@/util';
 import { getServerByTitleID } from '@/database';
 import { NASCRequestParams } from '@/types/services/nasc/request-params';
 import { HydratedServerDocument } from '@/types/mongoose/server';
@@ -83,7 +83,7 @@ async function processLoginRequest(server: HydratedServerDocument, pid: number, 
 		retry: nintendoBase64Encode('0'),
 		returncd: nintendoBase64Encode('001'),
 		token: nexToken,
-		datetime: nintendoBase64Encode(Date.now().toString()),
+		datetime: nintendoBase64Encode(nascDateTime()),
 	});
 }
 
@@ -108,7 +108,7 @@ async function processServiceTokenRequest(server: HydratedServerDocument, pid: n
 		servicetoken: serviceToken,
 		statusdata: nintendoBase64Encode('Y'),
 		svchost: nintendoBase64Encode('n/a'),
-		datetime: nintendoBase64Encode(Date.now().toString()),
+		datetime: nintendoBase64Encode(nascDateTime()),
 	});
 }
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -167,11 +167,24 @@ export async function writeLocalCDNFile(key: string, data: Buffer): Promise<void
 	await fs.writeFile(filePath, data);
 }
 
+export function nascDateTime(): string {
+	const now = new Date();
+
+	const year = now.getFullYear();
+	const month = (now.getMonth() + 1).toString().padStart(2, '0'); // * Months are zero-based
+	const day = now.getDate().toString().padStart(2, '0');
+	const hours = now.getHours().toString().padStart(2, '0');
+	const minutes = now.getMinutes().toString().padStart(2, '0');
+	const seconds = now.getSeconds().toString().padStart(2, '0');
+
+	return `${year}${month}${day}${hours}${minutes}${seconds}`;
+}
+
 export function nascError(errorCode: string): URLSearchParams {
 	return new URLSearchParams({
 		retry: nintendoBase64Encode('1'),
 		returncd: errorCode == 'null' ? errorCode : nintendoBase64Encode(errorCode),
-		datetime: nintendoBase64Encode(Date.now().toString()),
+		datetime: nintendoBase64Encode(nascDateTime()),
 	});
 }
 


### PR DESCRIPTION
The `datetime` field in NASC responses is not the Unix timestamp. It's a date and time field in the format `YYYYMMDDHHmmSS`.

PR adds a new `nascDateTime` function to get this string and updates the `datetime` usage