### PR TITLE
support: implement send_confirmation/pin/:email

### DIFF
--- a/src/services/nnid/routes/support.js
+++ b/src/services/nnid/routes/support.js
@@ -118,6 +118,33 @@ router.get('/resend_confirmation', async (request, response) => {
 
 /**
  * [GET]
+ * Replacement for: https://account.nintendo.net/v1/api/support/send_confirmation/pin/:email/
+ * Description: Sends a users confirmation email
+ */
+router.get('/send_confirmation/pin/:email/', async (request, response) => {
+	const { email } = request.params;
+
+	const pnid = await database.getUserByEmailAddress(email);
+
+	if (!pnid) {
+		// TODO - Unsure if this is the right error
+		return response.status(400).send(xmlbuilder.create({
+			errors: {
+				error: {
+					code: '0130',
+					message: 'PID has not been registered yet'
+				}
+			}
+		}).end());
+	}
+
+	await util.sendConfirmationEmail(pnid);
+
+	response.status(200).send('');
+});
+
+/**
+ * [GET]
  * Replacement for: https://account.nintendo.net/v1/api/support/forgotten_password/PID
  * Description: Sends the user a password reset email
  * NOTE: On NN this was a temp password that expired after 24 hours. We do not do that


### PR DESCRIPTION
Resolves #96

### Changes:

- Implements the `send_confirmation/pin/:email` route. Same as `resend_confirmation` but pulls PNID by email address.

- [X] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [X] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [X] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [ ] I have tested all of my changes.