### PR TITLE
Implement email confirmation for parental controls (send_confirmation/pin/:email)

### DIFF
--- a/src/services/nnas/routes/support.ts
+++ b/src/services/nnas/routes/support.ts
@@ -3,7 +3,7 @@ import express from 'express';
 import xmlbuilder from 'xmlbuilder';
 import moment from 'moment';
 import { getPNIDByEmailAddress, getPNIDByPID } from '@/database';
-import { sendEmailConfirmedEmail, sendConfirmationEmail, sendForgotPasswordEmail } from '@/util';
+import { sendEmailConfirmedEmail, sendConfirmationEmail, sendForgotPasswordEmail, sendEmailConfirmedParentalControlsEmail } from '@/util';
 
 const router = express.Router();
 
@@ -128,7 +128,7 @@ router.get('/resend_confirmation', async (request: express.Request, response: ex
 /**
  * [GET]
  * Replacement for: https://account.nintendo.net/v1/api/support/send_confirmation/pin/:email
- * Description: Sends a users confirmation email
+ * Description: Sends a users confirmation email that their email has been registered for parental controls
  */
 router.get('/send_confirmation/pin/:email', async (request: express.Request, response: express.Response): Promise<void> => {
 	const email = request.params.email;
@@ -149,7 +149,7 @@ router.get('/send_confirmation/pin/:email', async (request: express.Request, res
 		return;
 	}
 
-	await sendConfirmationEmail(pnid);
+	await sendEmailConfirmedParentalControlsEmail(pnid);
 
 	response.status(200).send('');
 });

--- a/src/services/nnas/routes/support.ts
+++ b/src/services/nnas/routes/support.ts
@@ -131,7 +131,7 @@ router.get('/resend_confirmation', async (request: express.Request, response: ex
  * Description: Sends a users confirmation email
  */
 router.get('/send_confirmation/pin/:email', async (request: express.Request, response: express.Response): Promise<void> => {
-	const email = String(request.params.email)
+	const email = request.params.email;
 
 	const pnid = await getPNIDByEmailAddress(email);
 

--- a/src/services/nnas/routes/support.ts
+++ b/src/services/nnas/routes/support.ts
@@ -2,7 +2,7 @@ import dns from 'node:dns';
 import express from 'express';
 import xmlbuilder from 'xmlbuilder';
 import moment from 'moment';
-import { getPNIDByPID } from '@/database';
+import { getPNIDByEmailAddress, getPNIDByPID } from '@/database';
 import { sendEmailConfirmedEmail, sendConfirmationEmail, sendForgotPasswordEmail } from '@/util';
 
 const router = express.Router();
@@ -105,6 +105,35 @@ router.get('/resend_confirmation', async (request: express.Request, response: ex
 	const pid = Number(request.headers['x-nintendo-pid']);
 
 	const pnid = await getPNIDByPID(pid);
+
+	if (!pnid) {
+		// TODO - Unsure if this is the right error
+		response.status(400).send(xmlbuilder.create({
+			errors: {
+				error: {
+					code: '0130',
+					message: 'PID has not been registered yet'
+				}
+			}
+		}).end());
+
+		return;
+	}
+
+	await sendConfirmationEmail(pnid);
+
+	response.status(200).send('');
+});
+
+/**
+ * [GET]
+ * Replacement for: https://account.nintendo.net/v1/api/support/send_confirmation/pin/:email
+ * Description: Sends a users confirmation email
+ */
+router.get('/send_confirmation/pin/:email', async (request: express.Request, response: express.Response): Promise<void> => {
+	const email = String(request.params.email)
+
+	const pnid = await getPNIDByEmailAddress(email);
 
 	if (!pnid) {
 		// TODO - Unsure if this is the right error

--- a/src/util.ts
+++ b/src/util.ts
@@ -219,6 +219,18 @@ export async function sendEmailConfirmedEmail(pnid: mongoose.HydratedDocument<IP
 	await sendMail(options);
 }
 
+export async function sendEmailConfirmedParentalControlsEmail(pnid: mongoose.HydratedDocument<IPNID, IPNIDMethods>): Promise<void>  {
+	const options = {
+		to: pnid.email.address,
+		subject: '[Pretendo Network] Email address confirmed for Parental Controls',
+		username: pnid.username,
+		paragraph: 'your email address has been confirmed for use with Parental Controls.',
+		text: `Dear ${pnid.username}, \r\n\r\nYour email address has been confirmed for use with Parental Controls.`
+	};
+
+	await sendMail(options);
+}
+
 export async function sendForgotPasswordEmail(pnid: mongoose.HydratedDocument<IPNID, IPNIDMethods>): Promise<void> {
 	const tokenOptions = {
 		system_type: 0xF, // * API


### PR DESCRIPTION
Resolves #96 

### Changes:

- Implements the `send_confirmation/pin/:email` route. Same method as `resend_confirmation` but gets the PNID from the database via email address instead off PID.

- [X] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [X] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [X] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [X] I have tested all of my changes.