### PR TITLE
Return the PNID's Stripe tier name and level from the PNID details API

### DIFF
--- a/src/services/api/routes/v1/user.ts
+++ b/src/services/api/routes/v1/user.ts
@@ -62,6 +62,10 @@ router.get('/', async (request: express.Request, response: express.Response): Pr
 		connections: {
 			discord: {
 				id: pnid.connections.discord.id
+			},
+			stripe: {
+				tier_name: pnid.connections.stripe.tier_name,
+				tier_level: pnid.connections.stripe.tier_level
 			}
 		}
 	});


### PR DESCRIPTION
This is a necessary for PretendoNetwork/website#345

### Changes:

This modifies the `GET https://api.pretendo.cc/v1/user` API to return the PNID's Stripe tier name and level. This is necessary for Discourse group syncing because the Discourse SSO route on the website calls this API to retreive account details, and the tier name/level will be needed to sync the supporter groups.

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [x] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [x] I have tested all of my changes.