### PR TITLE
Check email validity when linking existing PNID

### DIFF
--- a/src/middleware/pnid.ts
+++ b/src/middleware/pnid.ts
@@ -53,6 +53,19 @@ async function PNIDMiddleware(request: express.Request, response: express.Respon
 		return;
 	}
 
+	if (pnid.email.address !== email) {
+		response.status(401).send(xmlbuilder.create({
+			errors: {
+				error: {
+					code: '1105',
+					message: 'Email address, username, or password, is not valid'
+				}
+			}
+		}).end());
+
+		return;
+	}
+
 	if (pnid.deleted) {
 		response.status(400).send(xmlbuilder.create({
 			errors: {


### PR DESCRIPTION
Resolves #28

### Changes:

This commit adds a check after the username/password check to ensure the submitted email matches the user's email. 

The error code (022-2613 / 1105 in source code) is correct for any case where username/password/email are incorrect according to [Nintendo](https://en-americas-support.nintendo.com/app/answers/detail/a_id/4314).

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [x] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [x] I have tested all of my changes.