### PR TITLE
Add the correct banned error codes

### DIFF
--- a/src/middleware/pnid.ts
+++ b/src/middleware/pnid.ts
@@ -70,8 +70,8 @@ async function PNIDMiddleware(request: express.Request, response: express.Respon
 		response.status(400).send(xmlbuilder.create({
 			errors: {
 				error: {
-					code: '0122',
-					message: 'Device has been banned by game server'
+					code: '0108',
+					message: 'Account has been banned'
 				}
 			}
 		}).end());

--- a/src/services/nnas/routes/oauth.ts
+++ b/src/services/nnas/routes/oauth.ts
@@ -144,8 +144,8 @@ router.post('/access_token/generate', deviceCertificateMiddleware, consoleStatus
 		response.status(400).send(xmlbuilder.create({
 			errors: {
 				error: {
-					code: '0122',
-					message: 'Device has been banned by game server'
+					code: '0108',
+					message: 'Account has been banned'
 				}
 			}
 		}).end());


### PR DESCRIPTION
<!--

* Before making a pull request, ensure the changes are for an approved issue.
* If your changes are not for an approved issue, your pull request can and will be rejected.
*
* CHECK https://github.com/PretendoNetwork/REPO_NAME/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved
* FOR APPROVED ISSUES!

-->

Resolves #120

### Changes:

Replaces the 102-2814 (`BANNED_DEVICE_ALL`) error code when an account is banned with 102-2802 (`BANNED_ACCOUNT_ALL`).

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [x] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [x] I have tested all of my changes.