### PR TITLE
Return the server a tier below if it does not exist

### DIFF
--- a/src/database.ts
+++ b/src/database.ts
@@ -212,14 +212,15 @@ export async function getPNIDProfileJSONByPID(pid: number): Promise<PNIDProfile 
 }
 
 export async function getServerByGameServerID(gameServerID: string, accessMode: string): Promise<HydratedServerDocument | null> {
-	const searchModes = accessModeOrder[accessMode] || ['prod'];
+	const searchModes = accessModeOrder[accessMode] ?? accessModeOrder.prod; // Default to prod if invalid mode
+
+	const servers = await Server.find({
+		game_server_id: gameServerID,
+		access_mode: { $in: searchModes }
+	})
 
 	for (const mode of searchModes) {
-		const server = await Server.findOne({
-			game_server_id: gameServerID,
-			access_mode: mode
-		});
-
+		const server = servers.find(s => s.access_mode === mode);
 		if (server) return server;
 	}
 
@@ -227,14 +228,15 @@ export async function getServerByGameServerID(gameServerID: string, accessMode: 
 }
 
 export async function getServerByTitleID(titleID: string, accessMode: string): Promise<HydratedServerDocument | null> {
-	const searchModes = accessModeOrder[accessMode] || ['prod'];
+	const searchModes = accessModeOrder[accessMode] ?? accessModeOrder.prod;
+
+	const servers = await Server.find({
+		title_ids: titleID,
+		access_mode: { $in: searchModes }
+	})
 
 	for (const mode of searchModes) {
-		const server = await Server.findOne({
-			title_ids: titleID,
-			access_mode: mode
-		});
-
+		const server = servers.find(s => s.access_mode === mode);
 		if (server) return server;
 	}
 
@@ -242,20 +244,20 @@ export async function getServerByTitleID(titleID: string, accessMode: string): P
 }
 
 export async function getServerByClientID(clientID: string, accessMode: string): Promise<HydratedServerDocument | null> {
-	const searchModes = accessModeOrder[accessMode] || ['prod'];
+	const searchModes = accessModeOrder[accessMode] ?? accessModeOrder.prod;
+
+	const servers = await Server.find({
+		client_id: clientID,
+		access_mode: { $in: searchModes }
+	})
 
 	for (const mode of searchModes) {
-		const server = await Server.findOne({
-			client_id: clientID,
-			access_mode: mode
-		});
-
+		const server = servers.find(s => s.access_mode === mode);
 		if (server) return server;
 	}
 
 	return null;
 }
-
 
 export async function addPNIDConnection(pnid: HydratedPNIDDocument, data: ConnectionData, type: string): Promise<ConnectionResponse | undefined> {
 	if (type === 'discord') {

--- a/src/database.ts
+++ b/src/database.ts
@@ -217,7 +217,7 @@ export async function getServerByGameServerID(gameServerID: string, accessMode: 
 	const servers = await Server.find({
 		game_server_id: gameServerID,
 		access_mode: { $in: searchModes }
-	})
+	});
 
 	for (const mode of searchModes) {
 		const server = servers.find(s => s.access_mode === mode);
@@ -233,7 +233,7 @@ export async function getServerByTitleID(titleID: string, accessMode: string): P
 	const servers = await Server.find({
 		title_ids: titleID,
 		access_mode: { $in: searchModes }
-	})
+	});
 
 	for (const mode of searchModes) {
 		const server = servers.find(s => s.access_mode === mode);
@@ -249,7 +249,7 @@ export async function getServerByClientID(clientID: string, accessMode: string):
 	const servers = await Server.find({
 		client_id: clientID,
 		access_mode: { $in: searchModes }
-	})
+	});
 
 	for (const mode of searchModes) {
 		const server = servers.find(s => s.access_mode === mode);

--- a/src/database.ts
+++ b/src/database.ts
@@ -22,6 +22,12 @@ const discordConnectionSchema = joi.object({
 	id: joi.string()
 });
 
+const accessModeOrder: Record<string, string[]> = {
+	prod: ['prod'],
+	test: ['test', 'prod'],
+	dev: ['dev', 'test', 'prod']
+};
+
 let _connection: mongoose.Connection;
 
 export async function connect(): Promise<void> {
@@ -206,24 +212,48 @@ export async function getPNIDProfileJSONByPID(pid: number): Promise<PNIDProfile 
 }
 
 export async function getServerByGameServerID(gameServerID: string, accessMode: string): Promise<HydratedServerDocument | null> {
-	return await Server.findOne({
-		game_server_id: gameServerID,
-		access_mode: accessMode
-	});
+	const searchModes = accessModeOrder[accessMode] || ['prod'];
+
+	for (const mode of searchModes) {
+		const server = await Server.findOne({
+			game_server_id: gameServerID,
+			access_mode: mode
+		});
+
+		if (server) return server;
+	}
+
+	return null;
 }
 
 export async function getServerByTitleID(titleID: string, accessMode: string): Promise<HydratedServerDocument | null> {
-	return await Server.findOne({
-		title_ids: titleID,
-		access_mode: accessMode
-	});
+	const searchModes = accessModeOrder[accessMode] || ['prod'];
+
+	for (const mode of searchModes) {
+		const server = await Server.findOne({
+			title_ids: titleID,
+			access_mode: mode
+		});
+
+		if (server) return server;
+	}
+
+	return null;
 }
 
 export async function getServerByClientID(clientID: string, accessMode: string): Promise<HydratedServerDocument | null> {
-	return await Server.findOne({
-		client_id: clientID,
-		access_mode: accessMode
-	});
+	const searchModes = accessModeOrder[accessMode] || ['prod'];
+
+	for (const mode of searchModes) {
+		const server = await Server.findOne({
+			client_id: clientID,
+			access_mode: mode
+		});
+
+		if (server) return server;
+	}
+
+	return null;
 }
 
 


### PR DESCRIPTION
Resolves #150

### Changes:

If a server does not exist in a tier, use the tier below it.
For example, if a user is in the test access level, but a server for that game only exists on prod, use that server.
Same for the dev access level, but it goes dev --> test --> prod.

This time I set the base branch to `dev`, ignore the old PR.

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [x] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [x] I have tested all of my changes.