### PR TITLE
Update NNAS response/error handling

### DIFF
--- a/src/middleware/nnas-basic-header-check.ts
+++ b/src/middleware/nnas-basic-header-check.ts
@@ -1,5 +1,5 @@
 import express from 'express';
-import xmlbuilder from 'xmlbuilder';
+import { createNNASErrorResponse } from '@/services/nnas/create-response';
 
 const VALID_CLIENT_ID_SECRET_PAIRS: Record<string, string> = {
 	// * 'Key' is the client ID, 'Value' is the client secret
@@ -50,14 +50,14 @@ function nnasBasicHeaderCheckMiddleware(request: express.Request, response: expr
 
 	// * 0 = 3DS, 1 = Wii U
 	if (platformID === undefined || (platformID !== '0' && platformID !== '1')) {
-		response.send(xmlbuilder.create({
-			errors: {
-				error: {
+		return createNNASErrorResponse(response, {
+			errors: [
+				{
 					code: '0002',
 					message: 'platformId format is invalid'
 				}
-			}
-		}).end());
+			]
+		});
 
 		return;
 	}
@@ -65,80 +65,80 @@ function nnasBasicHeaderCheckMiddleware(request: express.Request, response: expr
 	// * 1 = debug, 2 = retail
 	if (deviceType === undefined || (deviceType !== '1' && deviceType !== '2')) {
 		// TODO - Unsure if this is the right error
-		response.send(xmlbuilder.create({
-			errors: {
-				error: {
+		return createNNASErrorResponse(response, {
+			errors: [
+				{
 					code: '0002',
 					message: 'Device type format is invalid'
 				}
-			}
-		}).end());
+			]
+		});
 
 		return;
 	}
 
 	if (deviceID === undefined || !DEVICE_ID.test(deviceID)) {
-		response.send(xmlbuilder.create({
-			errors: {
-				error: {
+		return createNNASErrorResponse(response, {
+			errors: [
+				{
 					code: '0002',
 					message: 'deviceId format is invalid'
 				}
-			}
-		}).end());
+			]
+		});
 
 		return;
 	}
 
 	if (serialNumber === undefined || !SERIAL_REGEX.test(serialNumber)) {
-		response.send(xmlbuilder.create({
-			errors: {
-				error: {
+		return createNNASErrorResponse(response, {
+			errors: [
+				{
 					code: '0002',
 					message: 'serialNumber format is invalid'
 				}
-			}
-		}).end());
+			]
+		});
 
 		return;
 	}
 
 	// TODO - Should the version check throw SYSTEM_UPDATE_REQUIRED?
 	if (systemVersion === undefined || SYSTEM_VERSIONS[platformID] !== systemVersion) {
-		response.send(xmlbuilder.create({
-			errors: {
-				error: {
+		return createNNASErrorResponse(response, {
+			errors: [
+				{
 					code: '0002',
 					message: 'version format is invalid'
 				}
-			}
-		}).end());
+			]
+		});
 
 		return;
 	}
 
 	if (region === undefined || !REGIONS.includes(region)) {
-		response.send(xmlbuilder.create({
-			errors: {
-				error: {
+		return createNNASErrorResponse(response, {
+			errors: [
+				{
 					code: '0002',
 					message: 'X-Nintendo-Region format is invalid'
 				}
-			}
-		}).end());
+			]
+		});
 
 		return;
 	}
 
 	if (country === undefined) {
-		response.send(xmlbuilder.create({
-			errors: {
-				error: {
+		return createNNASErrorResponse(response, {
+			errors: [
+				{
 					code: '0002',
 					message: 'X-Nintendo-Country format is invalid'
 				}
-			}
-		}).end());
+			]
+		});
 
 		return;
 	}
@@ -150,112 +150,110 @@ function nnasBasicHeaderCheckMiddleware(request: express.Request, response: expr
 		!VALID_CLIENT_ID_SECRET_PAIRS[clientID] ||
 		clientSecret !== VALID_CLIENT_ID_SECRET_PAIRS[clientID]
 	) {
-		response.send(xmlbuilder.create({
-			errors: {
-				error: {
+		return createNNASErrorResponse(response, {
+			errors: [
+				{
 					cause: 'client_id',
 					code: '0004',
 					message: 'API application invalid or incorrect application credentials'
 				}
-			}
-		}).end());
+			]
+		});
 
 		return;
 	}
 
 	if (friendsVersion === undefined || friendsVersion !== '0000') {
 		// TODO - Unsure if this is the right error
-		response.send(xmlbuilder.create({
-			errors: {
-				error: {
+		return createNNASErrorResponse(response, {
+			errors: [
+				{
 					code: '0002',
 					message: 'Friends version is invalid'
 				}
-			}
-		}).end());
+			]
+		});
 
 		return;
 	}
 
 	// TODO - Check this against valid list
 	if (environment === undefined) {
-		response.send(xmlbuilder.create({
-			errors: {
-				error: {
+		return createNNASErrorResponse(response, {
+			errors: [
+				{
 					code: '1017',
 					message: 'The requested game environment wasn\'t found for the given game server.'
 				}
-			}
-		}).end());
+			]
+		});
 
 		return;
 	}
 
 	if (titleID === undefined) {
 		// TODO - Unsure if this is the right error
-		response.send(xmlbuilder.create({
-			errors: {
-				error: {
+		return createNNASErrorResponse(response, {
+			errors: [
+				{
 					code: '0002',
 					message: 'Title ID format is invalid'
 				}
-			}
-		}).end());
+			]
+		});
 
 		return;
 	}
 
 	if (uniqueID === undefined) {
 		// TODO - Unsure if this is the right error
-		response.send(xmlbuilder.create({
-			errors: {
-				error: {
+		return createNNASErrorResponse(response, {
+			errors: [
+				{
 					code: '0002',
 					message: 'Unique ID format is invalid'
 				}
-			}
-		}).end());
+			]
+		});
 
 		return;
 	}
 
 	if (applicationVersion === undefined) {
 		// TODO - Unsure if this is the right error
-		response.send(xmlbuilder.create({
-			errors: {
-				error: {
+		return createNNASErrorResponse(response, {
+			errors: [
+				{
 					code: '0002',
 					message: 'Application version format is invalid'
 				}
-			}
-		}).end());
+			]
+		});
 
 		return;
 	}
 
 	if (platformID === '0' && model === undefined) {
 		// TODO - Unsure if this is the right error
-		response.send(xmlbuilder.create({
-			errors: {
-				error: {
+		return createNNASErrorResponse(response, {
+			errors: [
+				{
 					code: '0002',
 					message: 'Model format is invalid'
 				}
-			}
-		}).end());
-
-		return;
+			]
+		});
 	}
 
 	if (platformID === '0' && deviceCertificate === undefined) {
-		response.status(400).send(xmlbuilder.create({
-			error: {
-				code: '0110',
-				message: 'Unlinked device'
-			}
-		}).end());
-
-		return;
+		return createNNASErrorResponse(response, {
+			errors: [
+				{
+					code: '0110',
+					message: 'Unlinked device'
+				}
+			]
+		});
 	}
 
 	return next();

--- a/src/middleware/nnas-check-device.ts
+++ b/src/middleware/nnas-check-device.ts
@@ -30,7 +30,7 @@ async function nnasCheckDeviceMiddleware(request: express.Request, response: exp
 	const platformID = request.header('X-Nintendo-Platform-ID')!;
 	const deviceID = Number(request.header('X-Nintendo-Device-ID')!);
 	const serialNumber = request.header('X-Nintendo-Serial-Number')!;
-	const deviceCertificate = request.header('X-Nintendo-Device-Cert');
+	const deviceCertificate = request.header('X-Nintendo-Device-Cert')?.split(', ')[0]; // * 3DS sends the device cert twice, and Express will format it into "VALUE1, VALUE2"
 	const path = request.originalUrl.split('?')[0];
 
 	if (platformID === '1' && INSECURE_WIIU_ENDPOINTS.some(regex => regex.test(path))) {
@@ -113,7 +113,8 @@ async function nnasCheckDeviceMiddleware(request: express.Request, response: exp
 		}
 
 		// * Update 3DS consoles to sync with the data from NASC
-		const certificateHash = crypto.createHash('sha256').update(Buffer.from(deviceCertificate, 'base64')).digest('base64');
+		const certificateBytes = Buffer.from(deviceCertificate, 'base64');
+		const certificateHash = crypto.createHash('sha256').update(certificateBytes).digest('base64');
 
 		if (device && !device.certificate_hash && certificate.consoleType === '3ds') {
 			// * First time seeing the 3DS in NNAS, link the device certificate

--- a/src/middleware/xml-parser.ts
+++ b/src/middleware/xml-parser.ts
@@ -1,7 +1,7 @@
 import express from 'express';
-import xmlbuilder from 'xmlbuilder';
 import { document as xmlParser } from 'xmlbuilder2';
 import { getValueFromHeaders, mapToObject } from '@/util';
+import { createNNASErrorResponse } from '@/services/nnas/create-response';
 
 function XMLMiddleware(request: express.Request, response: express.Response, next: express.NextFunction): void {
 	if (request.method == 'POST' || request.method == 'PUT') {
@@ -35,14 +35,15 @@ function XMLMiddleware(request: express.Request, response: express.Response, nex
 				request.body = mapToObject(request.body);
 			} catch (error) {
 				// TODO - This is not a real error code, check to see if better one exists
-				return response.status(401).send(xmlbuilder.create({
-					errors: {
-						error: {
+				return createNNASErrorResponse(response, {
+					status: 401,
+					errors: [
+						{
 							code: '0004',
 							message: 'XML parse error'
 						}
-					}
-				}).end());
+					]
+				});
 			}
 
 			next();

--- a/src/services/nnas/create-response.ts
+++ b/src/services/nnas/create-response.ts
@@ -1,0 +1,44 @@
+import express from 'express';
+import xmlbuilder from 'xmlbuilder';
+
+// TODO - I'm unsure if this is the best place for this file to be or the best place to put these functions. It's fine for now though
+// TODO - Support JSON mode
+
+type CreateNNASErrorResponseOptions = {
+	status?: number;
+	errors: {
+		cause?: string;
+		code?: string;
+		message?: string;
+	}[];
+}
+
+type CreateNNASResponseOptions = {
+	status?: number;
+	body: Record<string, any>;
+}
+
+// TODO - This can largely be removed once an upgrade to Express v5 is done, since v5 supports throwing errors in async routes
+export function createNNASErrorResponse(response: express.Response, options: CreateNNASErrorResponseOptions): void {
+	createNNASResponse(response, {
+		status: options.status || 400,
+		body: {
+			// TODO - This is NOT suitable for JSON mode. Hack to get xmlbuilder to properly build XML error lists in the way we need it to. NNAS formats JSON error lists as `{"errors":[{"code":"0107","message":"Account country and device country do not match"}]}`
+			errors: {
+				error: options.errors
+			}
+		}
+	});
+}
+
+export function createNNASResponse(response: express.Response, options: CreateNNASResponseOptions): void {
+	response.set('Content-Type', 'text/xml');
+	response.set('Server', 'Nintendo 3DS (http)');
+	response.set('X-Nintendo-Date', new Date().getTime().toString());
+
+	const body = xmlbuilder
+		.create(options.body)
+		.commentBefore('WARNING! DO NOT SHARE ANYTHING IN THIS REQUEST OR RESPONSE WITH UNTRUSTED USERS! REQUESTS AND RESPONSES CONTAIN SENSITIVE INFORMATION ABOUT YOUR DEVICE/ACCOUNT SUCH AS PASSWORDS, EMAILS, CERTIFICATES, ETC!').end();
+
+	response.status(options.status || 200).send(body);
+}

--- a/src/services/nnas/create-response.ts
+++ b/src/services/nnas/create-response.ts
@@ -16,6 +16,7 @@ type CreateNNASErrorResponseOptions = {
 type CreateNNASResponseOptions = {
 	status?: number;
 	body: Record<string, any>;
+	xmlbuilder_options?: xmlbuilder.CreateOptions
 }
 
 // TODO - This can largely be removed once an upgrade to Express v5 is done, since v5 supports throwing errors in async routes
@@ -37,7 +38,7 @@ export function createNNASResponse(response: express.Response, options: CreateNN
 	response.set('X-Nintendo-Date', new Date().getTime().toString());
 
 	const body = xmlbuilder
-		.create(options.body)
+		.create(options.body, options.xmlbuilder_options)
 		.commentBefore('WARNING! DO NOT SHARE ANYTHING IN THIS REQUEST OR RESPONSE WITH UNTRUSTED USERS! REQUESTS AND RESPONSES CONTAIN SENSITIVE INFORMATION ABOUT YOUR DEVICE/ACCOUNT SUCH AS PASSWORDS, EMAILS, CERTIFICATES, ETC!').end();
 
 	response.status(options.status || 200).send(body);

--- a/src/services/nnas/routes/admin.ts
+++ b/src/services/nnas/routes/admin.ts
@@ -1,6 +1,7 @@
 import express from 'express';
 import xmlbuilder from 'xmlbuilder';
 import { getValueFromQueryString } from '@/util';
+import { createNNASErrorResponse } from '@/services/nnas/create-response';
 import { PNID } from '@/models/pnid';
 
 const router = express.Router();
@@ -16,17 +17,15 @@ router.get('/mapped_ids', async (request: express.Request, response: express.Res
 	const input = getValueFromQueryString(request.query, 'input');
 
 	if (!inputType || !outputType || !input) {
-		response.status(400).send(xmlbuilder.create({
-			errors: {
-				error: {
+		return createNNASErrorResponse(response, {
+			errors: [
+				{
 					cause: 'Bad Request',
 					code: '1600',
 					message: 'Unable to process request'
 				}
-			}
-		}).end());
-
-		return;
+			]
+		});
 	}
 
 	let inputList = input.split(',');

--- a/src/services/nnas/routes/admin.ts
+++ b/src/services/nnas/routes/admin.ts
@@ -1,7 +1,6 @@
 import express from 'express';
-import xmlbuilder from 'xmlbuilder';
 import { getValueFromQueryString } from '@/util';
-import { createNNASErrorResponse } from '@/services/nnas/create-response';
+import { createNNASErrorResponse, createNNASResponse } from '@/services/nnas/create-response';
 import { PNID } from '@/models/pnid';
 
 const router = express.Router();
@@ -96,11 +95,13 @@ router.get('/mapped_ids', async (request: express.Request, response: express.Res
 		results.push(result);
 	}
 
-	response.send(xmlbuilder.create({
-		mapped_ids: {
-			mapped_id: results
+	return createNNASResponse(response, {
+		body: {
+			mapped_ids: {
+				mapped_id: results
+			}
 		}
-	}).end());
+	});
 });
 
 /**

--- a/src/services/nnas/routes/content.ts
+++ b/src/services/nnas/routes/content.ts
@@ -1,5 +1,5 @@
 import express from 'express';
-import xmlbuilder from 'xmlbuilder';
+import { createNNASResponse } from '@/services/nnas/create-response';
 import timezones from '@/services/nnas/timezones.json';
 
 const router = express.Router();
@@ -10,115 +10,113 @@ const router = express.Router();
  * Description: Sends the client requested agreement
  */
 router.get('/agreements/:type/:region/:version', (request: express.Request, response: express.Response): void => {
-	response.set('Content-Type', 'text/xml');
-	response.set('Server', 'Nintendo 3DS (http)');
-	response.set('X-Nintendo-Date', new Date().getTime().toString());
+	return createNNASResponse(response, {
+		body: {
+			agreements: {
+				agreement: [
+					{
+						country: 'US',
+						language: 'en',
+						language_name: 'English',
+						publish_date: '2014-09-29T20:07:35',
+						texts: {
+							'@xmlns:xsi': 'http://www.w3.org/2001/XMLSchema-instance',
+							'@xsi:type': 'chunkedStoredAgreementText',
 
-	response.send(xmlbuilder.create({
-		agreements: {
-			agreement: [
-				{
-					country: 'US',
-					language: 'en',
-					language_name: 'English',
-					publish_date: '2014-09-29T20:07:35',
-					texts: {
-						'@xmlns:xsi': 'http://www.w3.org/2001/XMLSchema-instance',
-						'@xsi:type': 'chunkedStoredAgreementText',
-
-						main_title: {
-							'#cdata': 'Pretendo Network Services Agreement'
+							main_title: {
+								'#cdata': 'Pretendo Network Services Agreement'
+							},
+							agree_text: {
+								'#cdata': 'I Accept'
+							},
+							non_agree_text: {
+								'#cdata': 'I Decline'
+							},
+							main_text: {
+								'@index': '1',
+								'#cdata': 'Welcome to Pretendo\'s Christmas public beta! This is supplied with no liability or warranty, and is a stress test of our current services.This test is not expected to last long- term, and the data may be kept for later testing; this data will not be shared outside of Pretendo, and will be deleted at the end of our testing period.'
+							},
+							sub_title: {
+								'#cdata': 'Privacy Policy'
+							},
+							sub_text: {
+								'@index': '1',
+								'#cdata': 'Welcome to Pretendo\'s Christmas public beta! This is supplied with no liability or warranty, and is a stress test of our current services.This test is not expected to last long- term, and the data may be kept for later testing; this data will not be shared outside of Pretendo, and will be deleted at the end of our testing period.'
+							},
 						},
-						agree_text: {
-							'#cdata': 'I Accept'
-						},
-						non_agree_text: {
-							'#cdata': 'I Decline'
-						},
-						main_text: {
-							'@index': '1',
-							'#cdata': 'Welcome to Pretendo\'s Christmas public beta! This is supplied with no liability or warranty, and is a stress test of our current services.This test is not expected to last long- term, and the data may be kept for later testing; this data will not be shared outside of Pretendo, and will be deleted at the end of our testing period.'
-						},
-						sub_title: {
-							'#cdata': 'Privacy Policy'
-						},
-						sub_text: {
-							'@index': '1',
-							'#cdata': 'Welcome to Pretendo\'s Christmas public beta! This is supplied with no liability or warranty, and is a stress test of our current services.This test is not expected to last long- term, and the data may be kept for later testing; this data will not be shared outside of Pretendo, and will be deleted at the end of our testing period.'
-						},
+						type: 'NINTENDO-NETWORK-EULA',
+						version: '0300',
 					},
-					type: 'NINTENDO-NETWORK-EULA',
-					version: '0300',
-				},
-				{
-					country: 'US',
-					language: 'en',
-					language_name: 'Español',
-					publish_date: '2014-09-29T20:07:35',
-					texts: {
-						'@xmlns:xsi': 'http://www.w3.org/2001/XMLSchema-instance',
-						'@xsi:type': 'chunkedStoredAgreementText',
+					{
+						country: 'US',
+						language: 'en',
+						language_name: 'Español',
+						publish_date: '2014-09-29T20:07:35',
+						texts: {
+							'@xmlns:xsi': 'http://www.w3.org/2001/XMLSchema-instance',
+							'@xsi:type': 'chunkedStoredAgreementText',
 
-						main_title: {
-							'#cdata': 'Pretendo Network Services Agreement'
+							main_title: {
+								'#cdata': 'Pretendo Network Services Agreement'
+							},
+							agree_text: {
+								'#cdata': 'I Accept'
+							},
+							non_agree_text: {
+								'#cdata': 'I Decline'
+							},
+							main_text: {
+								'@index': '1',
+								'#cdata': 'Welcome to Pretendo\'s Christmas public beta! This is supplied with no liability or warranty, and is a stress test of our current services.This test is not expected to last long- term, and the data may be kept for later testing; this data will not be shared outside of Pretendo, and will be deleted at the end of our testing period.'
+							},
+							sub_title: {
+								'#cdata': 'Privacy Policy'
+							},
+							sub_text: {
+								'@index': '1',
+								'#cdata': 'Welcome to Pretendo\'s Christmas public beta! This is supplied with no liability or warranty, and is a stress test of our current services.This test is not expected to last long- term, and the data may be kept for later testing; this data will not be shared outside of Pretendo, and will be deleted at the end of our testing period.'
+							},
 						},
-						agree_text: {
-							'#cdata': 'I Accept'
-						},
-						non_agree_text: {
-							'#cdata': 'I Decline'
-						},
-						main_text: {
-							'@index': '1',
-							'#cdata': 'Welcome to Pretendo\'s Christmas public beta! This is supplied with no liability or warranty, and is a stress test of our current services.This test is not expected to last long- term, and the data may be kept for later testing; this data will not be shared outside of Pretendo, and will be deleted at the end of our testing period.'
-						},
-						sub_title: {
-							'#cdata': 'Privacy Policy'
-						},
-						sub_text: {
-							'@index': '1',
-							'#cdata': 'Welcome to Pretendo\'s Christmas public beta! This is supplied with no liability or warranty, and is a stress test of our current services.This test is not expected to last long- term, and the data may be kept for later testing; this data will not be shared outside of Pretendo, and will be deleted at the end of our testing period.'
-						},
+						type: 'NINTENDO-NETWORK-EULA',
+						version: '0300',
 					},
-					type: 'NINTENDO-NETWORK-EULA',
-					version: '0300',
-				},
-				{
-					country: 'US',
-					language: 'en',
-					language_name: 'Français',
-					publish_date: '2014-09-29T20:07:35',
-					texts: {
-						'@xmlns:xsi': 'http://www.w3.org/2001/XMLSchema-instance',
-						'@xsi:type': 'chunkedStoredAgreementText',
+					{
+						country: 'US',
+						language: 'en',
+						language_name: 'Français',
+						publish_date: '2014-09-29T20:07:35',
+						texts: {
+							'@xmlns:xsi': 'http://www.w3.org/2001/XMLSchema-instance',
+							'@xsi:type': 'chunkedStoredAgreementText',
 
-						main_title: {
-							'#cdata': 'Pretendo Network Services Agreement'
+							main_title: {
+								'#cdata': 'Pretendo Network Services Agreement'
+							},
+							agree_text: {
+								'#cdata': 'I Accept'
+							},
+							non_agree_text: {
+								'#cdata': 'I Decline'
+							},
+							main_text: {
+								'@index': '1',
+								'#cdata': 'Welcome to Pretendo\'s Christmas public beta! This is supplied with no liability or warranty, and is a stress test of our current services.This test is not expected to last long- term, and the data may be kept for later testing; this data will not be shared outside of Pretendo, and will be deleted at the end of our testing period.'
+							},
+							sub_title: {
+								'#cdata': 'Privacy Policy'
+							},
+							sub_text: {
+								'@index': '1',
+								'#cdata': 'Welcome to Pretendo\'s Christmas public beta! This is supplied with no liability or warranty, and is a stress test of our current services.This test is not expected to last long- term, and the data may be kept for later testing; this data will not be shared outside of Pretendo, and will be deleted at the end of our testing period.'
+							},
 						},
-						agree_text: {
-							'#cdata': 'I Accept'
-						},
-						non_agree_text: {
-							'#cdata': 'I Decline'
-						},
-						main_text: {
-							'@index': '1',
-							'#cdata': 'Welcome to Pretendo\'s Christmas public beta! This is supplied with no liability or warranty, and is a stress test of our current services.This test is not expected to last long- term, and the data may be kept for later testing; this data will not be shared outside of Pretendo, and will be deleted at the end of our testing period.'
-						},
-						sub_title: {
-							'#cdata': 'Privacy Policy'
-						},
-						sub_text: {
-							'@index': '1',
-							'#cdata': 'Welcome to Pretendo\'s Christmas public beta! This is supplied with no liability or warranty, and is a stress test of our current services.This test is not expected to last long- term, and the data may be kept for later testing; this data will not be shared outside of Pretendo, and will be deleted at the end of our testing period.'
-						},
-					},
-					type: 'NINTENDO-NETWORK-EULA',
-					version: '0300',
-				}
-			]
+						type: 'NINTENDO-NETWORK-EULA',
+						version: '0300',
+					}
+				]
+			}
 		}
-	}).end());
+	});
 });
 
 /**
@@ -127,10 +125,6 @@ router.get('/agreements/:type/:region/:version', (request: express.Request, resp
  * Description: Sends the client the requested timezones
  */
 router.get('/time_zones/:countryCode/:language', (request: express.Request, response: express.Response): void => {
-	response.set('Content-Type', 'text/xml');
-	response.set('Server', 'Nintendo 3DS (http)');
-	response.set('X-Nintendo-Date', new Date().getTime().toString());
-
 	/*
 	// * Old method. Crashes WiiU when sending a list with over 32 entries, but otherwise works
 	// * countryTimezones is "countries-and-timezones" module
@@ -155,11 +149,13 @@ router.get('/time_zones/:countryCode/:language', (request: express.Request, resp
 	const regionLanguages = timezones[countryCode as keyof typeof timezones];
 	const regionTimezones = regionLanguages[language as keyof typeof regionLanguages] ? regionLanguages[language as keyof typeof regionLanguages] : Object.values(regionLanguages)[0];
 
-	response.send(xmlbuilder.create({
-		timezones: {
-			timezone: regionTimezones
+	return createNNASResponse(response, {
+		body: {
+			timezones: {
+				timezone: regionTimezones
+			}
 		}
-	}).end());
+	});
 });
 
 export default router;

--- a/src/services/nnas/routes/devices.ts
+++ b/src/services/nnas/routes/devices.ts
@@ -1,5 +1,5 @@
 import express from 'express';
-import xmlbuilder from 'xmlbuilder';
+import { createNNASResponse } from '@/services/nnas/create-response';
 
 const router = express.Router();
 
@@ -10,9 +10,11 @@ const router = express.Router();
  */
 router.get('/@current/status', async (request: express.Request, response: express.Response): Promise<void> => {
 	// TODO - Finish this
-	response.send(xmlbuilder.create({
-		device: ''
-	}).end());
+	return createNNASResponse(response, {
+		body: {
+			device: ''
+		}
+	});
 });
 
 export default router;

--- a/src/services/nnas/routes/miis.ts
+++ b/src/services/nnas/routes/miis.ts
@@ -1,6 +1,7 @@
 import express from 'express';
 import xmlbuilder from 'xmlbuilder';
 import { getValueFromQueryString } from '@/util';
+import { createNNASErrorResponse } from '@/services/nnas/create-response';
 import { PNID } from '@/models/pnid';
 import { config } from '@/config-manager';
 import { YesNoBoolString } from '@/types/common/yes-no-bool-string';
@@ -16,17 +17,15 @@ router.get('/', async (request: express.Request, response: express.Response): Pr
 	const input = getValueFromQueryString(request.query, 'pids');
 
 	if (!input) {
-		response.status(400).send(xmlbuilder.create({
-			errors: {
-				error: {
+		return createNNASErrorResponse(response, {
+			errors: [
+				{
 					cause: 'Bad Request',
 					code: '1600',
 					message: 'Unable to process request'
 				}
-			}
-		}).end());
-
-		return;
+			]
+		});
 	}
 
 	const pids = input.split(',').map(pid => Number(pid)).filter(pid => !isNaN(pid));

--- a/src/services/nnas/routes/miis.ts
+++ b/src/services/nnas/routes/miis.ts
@@ -1,7 +1,6 @@
 import express from 'express';
-import xmlbuilder from 'xmlbuilder';
 import { getValueFromQueryString } from '@/util';
-import { createNNASErrorResponse } from '@/services/nnas/create-response';
+import { createNNASErrorResponse, createNNASResponse } from '@/services/nnas/create-response';
 import { PNID } from '@/models/pnid';
 import { config } from '@/config-manager';
 import { YesNoBoolString } from '@/types/common/yes-no-bool-string';
@@ -118,11 +117,13 @@ router.get('/', async (request: express.Request, response: express.Response): Pr
 	if (miis.length === 0) {
 		response.status(404).end();
 	} else {
-		response.send(xmlbuilder.create({
-			miis: {
-				mii: miis
+		return createNNASResponse(response, {
+			body: {
+				miis: {
+					mii: miis
+				}
 			}
-		}).end());
+		});
 	}
 });
 

--- a/src/services/nnas/routes/oauth.ts
+++ b/src/services/nnas/routes/oauth.ts
@@ -1,9 +1,8 @@
 import express from 'express';
-import xmlbuilder from 'xmlbuilder';
 import bcrypt from 'bcrypt';
 import { getPNIDByNNASRefreshToken, getPNIDByUsername } from '@/database';
 import { generateOAuthTokens } from '@/util';
-import { createNNASErrorResponse } from '@/services/nnas/create-response';
+import { createNNASErrorResponse, createNNASResponse } from '@/services/nnas/create-response';
 import { Device } from '@/models/device';
 import { SystemType } from '@/types/common/token';
 
@@ -155,15 +154,17 @@ router.post('/access_token/generate', async (request: express.Request, response:
 	try {
 		const tokenGeneration = generateOAuthTokens(SystemType.WIIU, pnid);
 
-		response.send(xmlbuilder.create({
-			OAuth20: {
-				access_token: {
-					token: tokenGeneration.accessToken,
-					refresh_token: tokenGeneration.refreshToken,
-					expires_in: tokenGeneration.expiresInSecs.access
+		return createNNASResponse(response, {
+			body: {
+				OAuth20: {
+					access_token: {
+						token: tokenGeneration.accessToken,
+						refresh_token: tokenGeneration.refreshToken,
+						expires_in: tokenGeneration.expiresInSecs.access
+					}
 				}
 			}
-		}).commentBefore('WARNING! DO NOT SHARE ANYTHING IN THIS REQUEST OR RESPONSE WITH UNTRUSTED USERS! IT CAN BE USED TO IMPERSONATE YOU AND YOUR CONSOLE, POTENTIALLY GETTING YOU BANNED!').end()); // TODO - This is ugly
+		});
 	} catch {
 		response.status(500);
 	}

--- a/src/services/nnas/routes/people.ts
+++ b/src/services/nnas/routes/people.ts
@@ -6,6 +6,7 @@ import moment from 'moment';
 import ratelimit from '@/middleware/ratelimit';
 import { connection as databaseConnection, doesPNIDExist, getPNIDProfileJSONByPID } from '@/database';
 import { getValueFromHeaders, nintendoPasswordHash, sendConfirmationEmail, sendPNIDDeletedEmail } from '@/util';
+import { createNNASErrorResponse } from '@/services/nnas/create-response';
 import { PNID } from '@/models/pnid';
 import { NEXAccount } from '@/models/nex-account';
 import { LOG_ERROR } from '@/logger';
@@ -28,16 +29,14 @@ router.get('/:username', async (request: express.Request, response: express.Resp
 	const userExists = await doesPNIDExist(username);
 
 	if (userExists) {
-		response.status(400).send(xmlbuilder.create({
-			errors: {
-				error: {
+		return createNNASErrorResponse(response, {
+			errors: [
+				{
 					code: '0100',
 					message: 'Account ID already exists'
 				}
-			}
-		}).end());
-
-		return;
+			]
+		});
 	}
 
 	response.send();
@@ -54,16 +53,14 @@ router.post('/', ratelimit, async (request: express.Request, response: express.R
 	const userExists = await doesPNIDExist(person.user_id);
 
 	if (userExists) {
-		response.status(400).send(xmlbuilder.create({
-			errors: {
-				error: {
+		return createNNASErrorResponse(response, {
+			errors: [
+				{
 					code: '0100',
 					message: 'Account ID already exists'
 				}
-			}
-		}).end());
-
-		return;
+			]
+		});
 	}
 
 	const creationDate = moment().format('YYYY-MM-DDTHH:MM:SS');
@@ -168,15 +165,15 @@ router.post('/', ratelimit, async (request: express.Request, response: express.R
 
 		await session.abortTransaction();
 
-		response.status(400).send(xmlbuilder.create({
-			error: {
-				cause: 'Bad Request',
-				code: '1600',
-				message: 'Unable to process request'
-			}
-		}).end());
-
-		return;
+		return createNNASErrorResponse(response, {
+			errors: [
+				{
+					cause: 'Bad Request',
+					code: '1600',
+					message: 'Unable to process request'
+				}
+			]
+		});
 	} finally {
 		// * This runs regardless of failure
 		// * Returning on catch will not prevent this from running
@@ -206,34 +203,32 @@ router.get('/@me/profile', async (request: express.Request, response: express.Re
 
 	if (!pnid) {
 		// TODO - Research this error more
-		response.status(404).send(xmlbuilder.create({
-			errors: {
-				error: {
+		return createNNASErrorResponse(response, {
+			status: 404,
+			errors: [
+				{
 					cause: '',
 					code: '0008',
 					message: 'Not Found'
 				}
-			}
-		}).end());
-
-		return;
+			]
+		});
 	}
 
 	const person = await getPNIDProfileJSONByPID(pnid.pid);
 
 	if (!person) {
 		// TODO - Research this error more
-		response.status(404).send(xmlbuilder.create({
-			errors: {
-				error: {
+		return createNNASErrorResponse(response, {
+			status: 404,
+			errors: [
+				{
 					cause: '',
 					code: '0008',
 					message: 'Not Found'
 				}
-			}
-		}).end());
-
-		return;
+			]
+		});
 	}
 
 	response.send(xmlbuilder.create({
@@ -261,34 +256,32 @@ router.post('/@me/devices', async (request: express.Request, response: express.R
 
 	if (!pnid) {
 		// TODO - Research this error more
-		response.status(404).send(xmlbuilder.create({
-			errors: {
-				error: {
+		return createNNASErrorResponse(response, {
+			status: 404,
+			errors: [
+				{
 					cause: '',
 					code: '0008',
 					message: 'Not Found'
 				}
-			}
-		}).end());
-
-		return;
+			]
+		});
 	}
 
 	const person = await getPNIDProfileJSONByPID(pnid.pid);
 
 	if (!person) {
 		// TODO - Research this error more
-		response.status(404).send(xmlbuilder.create({
-			errors: {
-				error: {
+		return createNNASErrorResponse(response, {
+			status: 404,
+			errors: [
+				{
 					cause: '',
 					code: '0008',
 					message: 'Not Found'
 				}
-			}
-		}).end());
-
-		return;
+			]
+		});
 	}
 
 	response.send(xmlbuilder.create({
@@ -316,32 +309,29 @@ router.get('/@me/devices', async (request: express.Request, response: express.Re
 
 	if (!deviceID || !acceptLanguage || !platformID || !region || !serialNumber || !systemVersion) {
 		// TODO - Research these error more
-		response.status(400).send(xmlbuilder.create({
-			errors: {
-				error: {
+		return createNNASErrorResponse(response, {
+			errors: [
+				{
 					cause: 'Bad Request',
 					code: '1600',
 					message: 'Unable to process request'
 				}
-			}
-		}).end());
-
-		return;
+			]
+		});
 	}
 
 	if (!pnid) {
 		// TODO - Research this error more
-		response.status(404).send(xmlbuilder.create({
-			errors: {
-				error: {
+		return createNNASErrorResponse(response, {
+			status: 404,
+			errors: [
+				{
 					cause: '',
 					code: '0008',
 					message: 'Not Found'
 				}
-			}
-		}).end());
-
-		return;
+			]
+		});
 	}
 
 	response.send(xmlbuilder.create({
@@ -379,34 +369,32 @@ router.get('/@me/devices/owner', async (request: express.Request, response: expr
 
 	if (!pnid) {
 		// TODO - Research this error more
-		response.status(404).send(xmlbuilder.create({
-			errors: {
-				error: {
+		return createNNASErrorResponse(response, {
+			status: 404,
+			errors: [
+				{
 					cause: '',
 					code: '0008',
 					message: 'Not Found'
 				}
-			}
-		}).end());
-
-		return;
+			]
+		});
 	}
 
 	const person = await getPNIDProfileJSONByPID(pnid.pid);
 
 	if (!person) {
 		// TODO - Research this error more
-		response.status(404).send(xmlbuilder.create({
-			errors: {
-				error: {
+		return createNNASErrorResponse(response, {
+			status: 404,
+			errors: [
+				{
 					cause: '',
 					code: '0008',
 					message: 'Not Found'
 				}
-			}
-		}).end());
-
-		return;
+			]
+		});
 	}
 
 	response.send(xmlbuilder.create({
@@ -440,17 +428,16 @@ router.put('/@me/miis/@primary', async (request: express.Request, response: expr
 
 	if (!pnid) {
 		// TODO - Research this error more
-		response.status(404).send(xmlbuilder.create({
-			errors: {
-				error: {
+		return createNNASErrorResponse(response, {
+			status: 404,
+			errors: [
+				{
 					cause: '',
 					code: '0008',
 					message: 'Not Found'
 				}
-			}
-		}).end());
-
-		return;
+			]
+		});
 	}
 
 	const mii: {
@@ -482,17 +469,15 @@ router.put('/@me/devices/@current/inactivate', async (request: express.Request, 
 	const pnid = request.pnid;
 
 	if (!pnid) {
-		response.status(400).send(xmlbuilder.create({
-			errors: {
-				error: {
+		return createNNASErrorResponse(response, {
+			errors: [
+				{
 					cause: 'access_token',
 					code: '0002',
 					message: 'Invalid access token'
 				}
-			}
-		}).end());
-
-		return;
+			]
+		});
 	}
 
 	response.send();
@@ -507,17 +492,15 @@ router.post('/@me/deletion', async (request: express.Request, response: express.
 	const pnid = request.pnid;
 
 	if (!pnid) {
-		response.status(400).send(xmlbuilder.create({
-			errors: {
-				error: {
+		return createNNASErrorResponse(response, {
+			errors: [
+				{
 					cause: 'access_token',
 					code: '0002',
 					message: 'Invalid access token'
 				}
-			}
-		}).end());
-
-		return;
+			]
+		});
 	}
 
 	const email = pnid.email.address;
@@ -544,17 +527,15 @@ router.put('/@me', async (request: express.Request, response: express.Response):
 	const person: Person = request.body.person;
 
 	if (!pnid) {
-		response.status(400).send(xmlbuilder.create({
-			errors: {
-				error: {
+		return createNNASErrorResponse(response, {
+			errors: [
+				{
 					cause: 'access_token',
 					code: '0002',
 					message: 'Invalid access token'
 				}
-			}
-		}).end());
-
-		return;
+			]
+		});
 	}
 
 	const gender = person.gender ? person.gender : pnid.gender;
@@ -618,17 +599,15 @@ router.get('/@me/emails', async (request: express.Request, response: express.Res
 	const pnid = request.pnid;
 
 	if (!pnid) {
-		response.status(400).send(xmlbuilder.create({
-			errors: {
-				error: {
+		return createNNASErrorResponse(response, {
+			errors: [
+				{
 					cause: 'access_token',
 					code: '0002',
 					message: 'Invalid access token'
 				}
-			}
-		}).end());
-
-		return;
+			]
+		});
 	}
 
 	response.send(xmlbuilder.create({
@@ -663,17 +642,15 @@ router.put('/@me/emails/@primary', async (request: express.Request, response: ex
 	} = request.body.email;
 
 	if (!pnid || !email || !email.address) {
-		response.status(400).send(xmlbuilder.create({
-			errors: {
-				error: {
+		return createNNASErrorResponse(response, {
+			errors: [
+				{
 					cause: 'access_token',
 					code: '0002',
 					message: 'Invalid access token'
 				}
-			}
-		}).end());
-
-		return;
+			]
+		});
 	}
 
 	// TODO - Better email check

--- a/src/services/nnas/routes/provider.ts
+++ b/src/services/nnas/routes/provider.ts
@@ -2,6 +2,7 @@ import express from 'express';
 import xmlbuilder from 'xmlbuilder';
 import { getServerByClientID, getServerByGameServerID } from '@/database';
 import { generateToken, getValueFromHeaders, getValueFromQueryString, isSystemType } from '@/util';
+import { createNNASErrorResponse } from '@/services/nnas/create-response';
 import { NEXAccount } from '@/models/nex-account';
 import { SystemType, TokenOptions, TokenType } from '@/types/common/token';
 
@@ -16,78 +17,68 @@ router.get('/service_token/@me', async (request: express.Request, response: expr
 	const pnid = request.pnid;
 
 	if (!pnid) {
-		response.status(400).send(xmlbuilder.create({
-			errors: {
-				error: {
+		return createNNASErrorResponse(response, {
+			errors: [
+				{
 					cause: 'access_token',
 					code: '0002',
 					message: 'Invalid access token'
 				}
-			}
-		}).end());
-
-		return;
+			]
+		});
 	}
 
 	const clientID = getValueFromQueryString(request.query, 'client_id');
 
 	if (!clientID) {
 		// TODO - Research this error more
-		response.send(xmlbuilder.create({
-			errors: {
-				error: {
+		return createNNASErrorResponse(response, {
+			errors: [
+				{
 					code: '1021',
 					message: 'The requested game server was not found'
 				}
-			}
-		}).end());
-
-		return;
+			]
+		});
 	}
 
 	const titleID = getValueFromHeaders(request.headers, 'x-nintendo-title-id');
 
 	if (!titleID) {
 		// TODO - Research this error more
-		response.send(xmlbuilder.create({
-			errors: {
-				error: {
+		return createNNASErrorResponse(response, {
+			errors: [
+				{
 					code: '1021',
 					message: 'The requested game server was not found'
 				}
-			}
-		}).end());
-
-		return;
+			]
+		});
 	}
 
 	const serverAccessLevel = pnid.server_access_level;
 	const server = await getServerByClientID(clientID, serverAccessLevel);
 
 	if (!server || !server.aes_key) {
-		response.send(xmlbuilder.create({
-			errors: {
-				error: {
+		return createNNASErrorResponse(response, {
+			errors: [
+				{
 					code: '1021',
 					message: 'The requested game server was not found'
 				}
-			}
-		}).end());
-
-		return;
+			]
+		});
 	}
 
 	if (server.maintenance_mode) {
-		response.send(xmlbuilder.create({
-			errors: {
-				error: {
+		return createNNASErrorResponse(response, {
+			errors: [
+				{
 					code: '2002',
 					message: 'The requested game server is under maintenance'
 				}
-			}
-		}).end());
-
-		return;
+			]
+		});
 	}
 
 	if (!isSystemType(server.device)) {
@@ -125,17 +116,15 @@ router.get('/nex_token/@me', async (request: express.Request, response: express.
 	const pnid = request.pnid;
 
 	if (!pnid) {
-		response.status(400).send(xmlbuilder.create({
-			errors: {
-				error: {
+		return createNNASErrorResponse(response, {
+			errors: [
+				{
 					cause: 'access_token',
 					code: '0002',
 					message: 'Invalid access token'
 				}
-			}
-		}).end());
-
-		return;
+			]
+		});
 	}
 
 	const nexAccount = await NEXAccount.findOne({
@@ -143,77 +132,68 @@ router.get('/nex_token/@me', async (request: express.Request, response: express.
 	});
 
 	if (!nexAccount) {
-		response.status(404).send(xmlbuilder.create({
-			errors: {
-				error: {
+		return createNNASErrorResponse(response, {
+			status: 404,
+			errors: [
+				{
 					cause: '',
 					code: '0008',
 					message: 'Not Found'
 				}
-			}
-		}).end());
-
-		return;
+			]
+		});
 	}
 
 	const gameServerID = getValueFromQueryString(request.query, 'game_server_id');
 
 	if (!gameServerID) {
-		response.send(xmlbuilder.create({
-			errors: {
-				error: {
+		return createNNASErrorResponse(response, {
+			errors: [
+				{
 					code: '0118',
 					message: 'Unique ID and Game Server ID are not linked'
 				}
-			}
-		}).end());
-
-		return;
+			]
+		});
 	}
 
 	const serverAccessLevel = pnid.server_access_level;
 	const server = await getServerByGameServerID(gameServerID, serverAccessLevel);
 
 	if (!server || !server.aes_key) {
-		response.send(xmlbuilder.create({
-			errors: {
-				error: {
+		return createNNASErrorResponse(response, {
+			errors: [
+				{
 					code: '1021',
 					message: 'The requested game server was not found'
 				}
-			}
-		}).end());
-
-		return;
+			]
+		});
 	}
 
 	if (server.maintenance_mode) {
-		response.send(xmlbuilder.create({
-			errors: {
-				error: {
+		return createNNASErrorResponse(response, {
+			errors: [
+				{
 					code: '2002',
 					message: 'The requested game server is under maintenance'
 				}
-			}
-		}).end());
-
-		return;
+			]
+		});
 	}
 
 	const titleID = getValueFromHeaders(request.headers, 'x-nintendo-title-id');
 
 	if (!titleID) {
 		// TODO - Research this error more
-		response.send(xmlbuilder.create({
-			errors: {
-				error: {
+		return createNNASErrorResponse(response, {
+			errors: [
+				{
 					code: '1021',
 					message: 'The requested game server was not found'
 				}
-			}
-		}).end());
-
-		return;
+			]
+		});
 	}
 
 	if (!isSystemType(server.device)) {

--- a/src/services/nnas/routes/provider.ts
+++ b/src/services/nnas/routes/provider.ts
@@ -1,8 +1,7 @@
 import express from 'express';
-import xmlbuilder from 'xmlbuilder';
 import { getServerByClientID, getServerByGameServerID } from '@/database';
 import { generateToken, getValueFromHeaders, getValueFromQueryString, isSystemType } from '@/util';
-import { createNNASErrorResponse } from '@/services/nnas/create-response';
+import { createNNASErrorResponse, createNNASResponse } from '@/services/nnas/create-response';
 import { NEXAccount } from '@/models/nex-account';
 import { SystemType, TokenOptions, TokenType } from '@/types/common/token';
 
@@ -100,11 +99,13 @@ router.get('/service_token/@me', async (request: express.Request, response: expr
 	const serviceTokenBuffer = generateToken(server.aes_key, tokenOptions);
 	const serviceToken = request.isCemu ? serviceTokenBuffer.toString('hex') : serviceTokenBuffer.toString('base64');
 
-	response.send(xmlbuilder.create({
-		service_token: {
-			token: serviceToken
+	return createNNASResponse(response, {
+		body: {
+			service_token: {
+				token: serviceToken
+			}
 		}
-	}).end());
+	});
 });
 
 /**
@@ -219,15 +220,17 @@ router.get('/nex_token/@me', async (request: express.Request, response: express.
 		nexToken = Buffer.from(nexToken || '', 'base64').toString('hex');
 	}
 
-	response.send(xmlbuilder.create({
-		nex_token: {
-			host: server.ip,
-			nex_password: nexAccount.password,
-			pid: nexAccount.pid,
-			port: server.port,
-			token: nexToken
+	return createNNASResponse(response, {
+		body: {
+			nex_token: {
+				host: server.ip,
+				nex_password: nexAccount.password,
+				pid: nexAccount.pid,
+				port: server.port,
+				token: nexToken
+			}
 		}
-	}).end());
+	});
 });
 
 export default router;


### PR DESCRIPTION
Resolves #160

### Changes:

Centralizes the response creation for NNAS. These changes automatically apply the common headers, as well as adds a comment to every response warning users not to share details with untrusted people. Also adds some notes/groundwork for supporting JSON mode in NNAS. Also fixes 3DS cert parsing as a bonus

Some of our error responses were formatted incorrectly, omitting the outer `<errors>` tag. This resulted in `102-2402` (`BAD_FORMAT_REQUEST`) since the client could not handle the error response. Now that this is fixed, we should get more accurate error codes from users

Marking as draft since it still needs robust testing on a console. I did some quick sanity checks using curl, but that's not enough

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [x] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [ ] I have tested all of my changes.