### PR TITLE
Remove WUP check when adding PNID to device in NNAS oauth

### DIFF
--- a/src/services/nnas/routes/oauth.ts
+++ b/src/services/nnas/routes/oauth.ts
@@ -130,15 +130,13 @@ router.post('/access_token/generate', deviceCertificateMiddleware, consoleStatus
 
 	// * This are set/validated in consoleStatusVerificationMiddleware
 	// * It is always set, despite what Express might think
-	if (request.device?.model === 'wup') {
-		await Device.updateOne({
-			_id: request.device?._id
-		}, {
-			$addToSet: {
-				linked_pids: pnid.pid
-			}
-		});
-	}
+	await Device.updateOne({
+		_id: request.device!._id
+	}, {
+		$addToSet: {
+			linked_pids: pnid.pid
+		}
+	});
 
 	if (pnid.access_level < 0) {
 		response.status(400).send(xmlbuilder.create({


### PR DESCRIPTION
Resolves #XXX

### Changes:

For some reason we were checking for Wii U devices in `/v1/api/oauth20/access_token/generate` of NNAS, resulting in PNIDs not being properly added to 3DS devices. This removes that check.

Not pushing directly because the check seemed deliberate, but no one can seem to remember why it was added? This *shouldn't* break anything (as it would just make the 3DS have the same behavior as the Wii U?), but doing a PR just in case.

No official issue was made here but it was raised on Discord.

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [x] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [ ] I have tested all of my changes.