### PR TITLE
Remove unique constraint from 6 digit email code

### DIFF
--- a/src/models/pnid.ts
+++ b/src/models/pnid.ts
@@ -90,10 +90,7 @@ const PNIDSchema = new Schema<IPNID, PNIDModel, IPNIDMethods>({
 	},
 	devices: [DeviceSchema],
 	identification: { // * user identification tokens
-		email_code: {
-			type: String,
-			unique: true
-		},
+		email_code: String,
 		email_token: {
 			type: String,
 			unique: true


### PR DESCRIPTION
Resolves #XXX

### Changes:

Brings over the changes from [`302956d` (#111)](https://github.com/PretendoNetwork/account/pull/111/commits/302956d5f2508f96e3a2394db9a32caf728f0696) back upstream. Fixes the issue where duplicate email codes are being rejected, these do not need to be unique

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [ ] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [ ] I have tested all of my changes.