### PR TITLE
Update PNID scrubbing functionality and add account deletion gRPC endpoints

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -64,29 +64,32 @@ The Pretendo Network website uses this server as an API for querying user inform
 
 Configurations are loaded through environment variables. `.env` files are supported. All configuration options will be gone over, both required and optional. There also exists an example `.env` file
 
-| Name                                          | Description                                                                                    | Optional |
-| --------------------------------------------- | ---------------------------------------------------------------------------------------------- | -------- |
-| `PN_ACT_CONFIG_HTTP_PORT`                     | The HTTP port the server listens on                                                            | No       |
-| `PN_ACT_CONFIG_IP2LOCATION_TOKEN`             | Download token for https://lite.ip2location.com. Used to download the local IP databases       | Yes      |
-| `PN_ACT_CONFIG_MONGO_CONNECTION_STRING`       | MongoDB connection string                                                                      | No       |
-| `PN_ACT_CONFIG_MONGOOSE_CONNECT_OPTIONS_PATH` | Path to a `.json` file containing Mongoose connection options                                  | Yes      |
-| `PN_ACT_CONFIG_REDIS_URL`                     | Redis URL                                                                                      | Yes      |
-| `PN_ACT_CONFIG_EMAIL_SES_REGION`              | Amazon SES Region                                                                              | Yes      |
-| `PN_ACT_CONFIG_EMAIL_SES_ACCESS_KEY`          | Amazon SES Access Key                                                                          | Yes      |
-| `PN_ACT_CONFIG_EMAIL_SES_SECRET_KEY`          | Amazon SES Access Secret                                                                       | Yes      |
-| `PN_ACT_CONFIG_EMAIL_FROM`                    | Email "from" address                                                                           | Yes      |
-| `PN_ACT_CONFIG_S3_ENDPOINT`                   | s3 server endpoint                                                                             | Yes      |
-| `PN_ACT_CONFIG_S3_ACCESS_KEY`                 | s3 secret key                                                                                  | Yes      |
-| `PN_ACT_CONFIG_S3_ACCESS_SECRET`              | s3 secret                                                                                      | Yes      |
-| `PN_ACT_CONFIG_HCAPTCHA_SECRET`               | hCaptcha secret (in the form `0x...`)                                                          | Yes      |
-| `PN_ACT_CONFIG_CDN_SUBDOMAIN`                 | Subdomain used to serve CDN contents if s3 is disabled                                         | Yes      |
-| `PN_ACT_CONFIG_CDN_DISK_PATH`                 | File system path used to store CDN contents if s3 is disabled                                  | Yes      |
-| `PN_ACT_CONFIG_CDN_BASE_URL`                  | URL for serving CDN contents (usually the same as s3 endpoint)                                 | No       |
-| `PN_ACT_CONFIG_WEBSITE_BASE`                  | Website URL                                                                                    | Yes      |
-| `PN_ACT_CONFIG_AES_KEY`                       | AES-256 key used for encrypting tokens                                                         | No       |
-| `PN_ACT_CONFIG_DATASTORE_SIGNATURE_SECRET`    | HMAC secret key (16 bytes in hex format) used to sign uploaded DataStore files                 | No       |
-| `PN_ACT_CONFIG_GRPC_MASTER_API_KEY_ACCOUNT`   | Master API key to interact with the account gRPC service                                       | No       |
-| `PN_ACT_CONFIG_GRPC_MASTER_API_KEY_API`       | Master API key to interact with the API gRPC service                                           | No       |
-| `PN_ACT_CONFIG_GRPC_PORT`                     | gRPC server port                                                                               | No       |
-| `PN_ACT_CONFIG_STRIPE_SECRET_KEY`             | Stripe API key. Used to cancel subscriptions when scrubbing PNIDs                              | Yes      |
-| `PN_ACT_CONFIG_SERVER_ENVIRONMENT`            | Server environment. Currently only used by the Wii U Account Settings app. `prod`/`test`/`dev` | Yes      |
+| Name                                          | Description                                                                                                     | Optional |
+| --------------------------------------------- | --------------------------------------------------------------------------------------------------------------- | -------- |
+| `PN_ACT_CONFIG_HTTP_PORT`                     | The HTTP port the server listens on                                                                             | No       |
+| `PN_ACT_CONFIG_IP2LOCATION_TOKEN`             | Download token for https://lite.ip2location.com. Used to download the local IP databases                        | Yes      |
+| `PN_ACT_CONFIG_MONGO_CONNECTION_STRING`       | MongoDB connection string                                                                                       | No       |
+| `PN_ACT_CONFIG_MONGOOSE_CONNECT_OPTIONS_PATH` | Path to a `.json` file containing Mongoose connection options                                                   | Yes      |
+| `PN_ACT_CONFIG_REDIS_URL`                     | Redis URL                                                                                                       | Yes      |
+| `PN_ACT_CONFIG_EMAIL_SES_REGION`              | Amazon SES Region                                                                                               | Yes      |
+| `PN_ACT_CONFIG_EMAIL_SES_ACCESS_KEY`          | Amazon SES Access Key                                                                                           | Yes      |
+| `PN_ACT_CONFIG_EMAIL_SES_SECRET_KEY`          | Amazon SES Access Secret                                                                                        | Yes      |
+| `PN_ACT_CONFIG_EMAIL_FROM`                    | Email "from" address                                                                                            | Yes      |
+| `PN_ACT_CONFIG_S3_ENDPOINT`                   | s3 server endpoint                                                                                              | Yes      |
+| `PN_ACT_CONFIG_S3_ACCESS_KEY`                 | s3 secret key                                                                                                   | Yes      |
+| `PN_ACT_CONFIG_S3_ACCESS_SECRET`              | s3 secret                                                                                                       | Yes      |
+| `PN_ACT_CONFIG_HCAPTCHA_SECRET`               | hCaptcha secret (in the form `0x...`)                                                                           | Yes      |
+| `PN_ACT_CONFIG_CDN_SUBDOMAIN`                 | Subdomain used to serve CDN contents if s3 is disabled                                                          | Yes      |
+| `PN_ACT_CONFIG_CDN_DISK_PATH`                 | File system path used to store CDN contents if s3 is disabled                                                   | Yes      |
+| `PN_ACT_CONFIG_CDN_BASE_URL`                  | URL for serving CDN contents (usually the same as s3 endpoint)                                                  | No       |
+| `PN_ACT_CONFIG_WEBSITE_BASE`                  | Website URL                                                                                                     | Yes      |
+| `PN_ACT_CONFIG_AES_KEY`                       | AES-256 key used for encrypting tokens                                                                          | No       |
+| `PN_ACT_CONFIG_DATASTORE_SIGNATURE_SECRET`    | HMAC secret key (16 bytes in hex format) used to sign uploaded DataStore files                                  | No       |
+| `PN_ACT_CONFIG_GRPC_MASTER_API_KEY_ACCOUNT`   | Master API key to interact with the account gRPC service                                                        | No       |
+| `PN_ACT_CONFIG_GRPC_MASTER_API_KEY_API`       | Master API key to interact with the API gRPC service                                                            | No       |
+| `PN_ACT_CONFIG_GRPC_PORT`                     | gRPC server port                                                                                                | No       |
+| `PN_ACT_CONFIG_STRIPE_SECRET_KEY`             | Stripe API key. Used to cancel subscriptions when scrubbing PNIDs                                               | Yes      |
+| `PN_ACT_CONFIG_SERVER_ENVIRONMENT`            | Server environment. Currently only used by the Wii U Account Settings app. `prod`/`test`/`dev`                  | Yes      |
+| `PN_ACT_CONFIG_DISCOURSE_FORUM_URL`           | Used for anonymizing user accounts on Discourse during account deletion. Forum anonymization skipped if not set | No       |
+| `PN_ACT_CONFIG_DISCOURSE_API_KEY`             | Used for anonymizing user accounts on Discourse during account deletion. Forum anonymization skipped if not set | No       |
+| `PN_ACT_CONFIG_DISCOURSE_API_USERNAME`        | Used for anonymizing user accounts on Discourse during account deletion. Forum anonymization skipped if not set | No       |

--- a/SETUP.md
+++ b/SETUP.md
@@ -93,3 +93,6 @@ Configurations are loaded through environment variables. `.env` files are suppor
 | `PN_ACT_CONFIG_DISCOURSE_FORUM_URL`           | Used for anonymizing user accounts on Discourse during account deletion. Forum anonymization skipped if not set | No       |
 | `PN_ACT_CONFIG_DISCOURSE_API_KEY`             | Used for anonymizing user accounts on Discourse during account deletion. Forum anonymization skipped if not set | No       |
 | `PN_ACT_CONFIG_DISCOURSE_API_USERNAME`        | Used for anonymizing user accounts on Discourse during account deletion. Forum anonymization skipped if not set | No       |
+| `PN_ACT_CONFIG_GRPC_MIIVERSE_HOST`            | Used to remove Miiverse user data during account deletion                                                       | Yes      |
+| `PN_ACT_CONFIG_GRPC_MIIVERSE_PORT`            | Used to remove Miiverse user data during account deletion                                                       | Yes      |
+| `PN_ACT_CONFIG_GRPC_MIIVERSE_KEY_API`         | Used to remove Miiverse user data during account deletion                                                       | Yes      |

--- a/SETUP.md
+++ b/SETUP.md
@@ -90,9 +90,9 @@ Configurations are loaded through environment variables. `.env` files are suppor
 | `PN_ACT_CONFIG_GRPC_PORT`                     | gRPC server port                                                                                                | No       |
 | `PN_ACT_CONFIG_STRIPE_SECRET_KEY`             | Stripe API key. Used to cancel subscriptions when scrubbing PNIDs                                               | Yes      |
 | `PN_ACT_CONFIG_SERVER_ENVIRONMENT`            | Server environment. Currently only used by the Wii U Account Settings app. `prod`/`test`/`dev`                  | Yes      |
-| `PN_ACT_CONFIG_DISCOURSE_FORUM_URL`           | Used for anonymizing user accounts on Discourse during account deletion. Forum anonymization skipped if not set | No       |
-| `PN_ACT_CONFIG_DISCOURSE_API_KEY`             | Used for anonymizing user accounts on Discourse during account deletion. Forum anonymization skipped if not set | No       |
-| `PN_ACT_CONFIG_DISCOURSE_API_USERNAME`        | Used for anonymizing user accounts on Discourse during account deletion. Forum anonymization skipped if not set | No       |
-| `PN_ACT_CONFIG_GRPC_MIIVERSE_HOST`            | Used to remove Miiverse user data during account deletion                                                       | Yes      |
-| `PN_ACT_CONFIG_GRPC_MIIVERSE_PORT`            | Used to remove Miiverse user data during account deletion                                                       | Yes      |
-| `PN_ACT_CONFIG_GRPC_MIIVERSE_KEY_API`         | Used to remove Miiverse user data during account deletion                                                       | Yes      |
+| `PN_ACT_CONFIG_DISCOURSE_FORUM_URL`           | Used for anonymizing user accounts on Discourse during account deletion. Forum anonymization skipped if not set | Yes      |
+| `PN_ACT_CONFIG_DISCOURSE_API_KEY`             | Used for anonymizing user accounts on Discourse during account deletion. Forum anonymization skipped if not set | Yes      |
+| `PN_ACT_CONFIG_DISCOURSE_API_USERNAME`        | Used for anonymizing user accounts on Discourse during account deletion. Forum anonymization skipped if not set | Yes      |
+| `PN_ACT_CONFIG_GRPC_MIIVERSE_HOST`            | Used to remove Miiverse user data during account deletion                                                       | No       |
+| `PN_ACT_CONFIG_GRPC_MIIVERSE_PORT`            | Used to remove Miiverse user data during account deletion                                                       | No       |
+| `PN_ACT_CONFIG_GRPC_MIIVERSE_KEY_API`         | Used to remove Miiverse user data during account deletion                                                       | No       |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1227,13 +1227,13 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.2.tgz",
-      "integrity": "sha512-4SaFZCNfJqvk/kenHpI8xvN42DMaoycy4PzKc5otHxRswww1kAt82OlBuwRVLofCACCTZEcla2Ydxv8scMXaTg==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.5.tgz",
+      "integrity": "sha512-Z5kJ+wU3oA7MMIqVR9tyZRtjYPr4OC004Q4Rw7pgOKUOKkJfZ3O24nz3WYfGRpMDNmcOi3TwQOmgm7B7Tpii0w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^0.15.0",
+        "@eslint/core": "^0.15.2",
         "levn": "^0.4.1"
       },
       "engines": {
@@ -1241,9 +1241,9 @@
       }
     },
     "node_modules/@eslint/plugin-kit/node_modules/@eslint/core": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.0.tgz",
-      "integrity": "sha512-b7ePw78tEWWkpgZCDYkbqDOP8dmM6qe+AOC6iuJqlq1R/0ahMAeH3qynpnqKFGkMltrp44ohV4ubGyvLX28tzw==",
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.2.tgz",
+      "integrity": "sha512-78Md3/Rrxh83gCxoUc0EiciuOHsIITzLy53m3d9UyiW8y9Dj2D29FeETqyKA+BRK76tnTp6RXWb3pCay8Oyomg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1430,6 +1430,15 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@inquirer/ansi": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-1.0.0.tgz",
+      "integrity": "sha512-JWaTfCxI1eTmJ1BIv86vUfjVatOdxwD0DAVKYevY8SazeUUZtW+tNbsdejVO1GYE0GXJW1N1ahmiC3TFd+7wZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@inquirer/checkbox": {
       "version": "4.1.8",
       "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.1.8.tgz",
@@ -1476,14 +1485,14 @@
       }
     },
     "node_modules/@inquirer/core": {
-      "version": "10.1.13",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.13.tgz",
-      "integrity": "sha512-1viSxebkYN2nJULlzCxES6G9/stgHSepZ9LqqfdIGPHj5OHhiBUXVS0a6R0bEC2A+VL4D9w6QB66ebCr6HGllA==",
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.2.2.tgz",
+      "integrity": "sha512-yXq/4QUnk4sHMtmbd7irwiepjB8jXU0kkFRL4nr/aDBA2mDz13cMakEWdDwX3eSCTkk03kwcndD1zfRAIlELxA==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/figures": "^1.0.12",
-        "@inquirer/type": "^3.0.7",
-        "ansi-escapes": "^4.3.2",
+        "@inquirer/ansi": "^1.0.0",
+        "@inquirer/figures": "^1.0.13",
+        "@inquirer/type": "^3.0.8",
         "cli-width": "^4.1.0",
         "mute-stream": "^2.0.0",
         "signal-exit": "^4.1.0",
@@ -1503,14 +1512,14 @@
       }
     },
     "node_modules/@inquirer/editor": {
-      "version": "4.2.13",
-      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.13.tgz",
-      "integrity": "sha512-WbicD9SUQt/K8O5Vyk9iC2ojq5RHoCLK6itpp2fHsWe44VxxcA9z3GTWlvjSTGmMQpZr+lbVmrxdHcumJoLbMA==",
+      "version": "4.2.20",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.20.tgz",
+      "integrity": "sha512-7omh5y5bK672Q+Brk4HBbnHNowOZwrb/78IFXdrEB9PfdxL3GudQyDk8O9vQ188wj3xrEebS2M9n18BjJoI83g==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.13",
-        "@inquirer/type": "^3.0.7",
-        "external-editor": "^3.1.0"
+        "@inquirer/core": "^10.2.2",
+        "@inquirer/external-editor": "^1.0.2",
+        "@inquirer/type": "^3.0.8"
       },
       "engines": {
         "node": ">=18"
@@ -1546,10 +1555,47 @@
         }
       }
     },
+    "node_modules/@inquirer/external-editor": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.2.tgz",
+      "integrity": "sha512-yy9cOoBnx58TlsPrIxauKIFQTiyH+0MK4e97y4sV9ERbI+zDxw7i2hxHLCIEGIE/8PPvDxGhgzIOTSOWcs6/MQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chardet": "^2.1.0",
+        "iconv-lite": "^0.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/external-editor/node_modules/iconv-lite": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.0.tgz",
+      "integrity": "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/@inquirer/figures": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.12.tgz",
-      "integrity": "sha512-MJttijd8rMFcKJC8NYmprWr6hD3r9Gd9qUC0XwPNwoEPWSMVJwA2MlXxF+nhZZNMY+HXsWa+o7KY2emWYIn0jQ==",
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.13.tgz",
+      "integrity": "sha512-lGPVU3yO9ZNqA7vTYz26jny41lE7yoQansmqdMLBEfqaGsmdg7V3W9mK9Pvb5IL4EVZ9GnSDGMO/cJXud5dMaw==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -1718,9 +1764,9 @@
       }
     },
     "node_modules/@inquirer/type": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.7.tgz",
-      "integrity": "sha512-PfunHQcjwnju84L+ycmcMKB/pTPIngjUJvfnRhKY6FKPuYXlM4aQCb/nIdTFR6BEhMjFvngzvng/vBAJMZpLSA==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.8.tgz",
+      "integrity": "sha512-lg9Whz8onIHRthWaN1Q9EGLa/0LFJjyM8mEUbL1eTi6yMGvBf8gvyDLtxSXztQsxMvhxxNpJYrwa1YHdq+w4Jw==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -4698,9 +4744,9 @@
       }
     },
     "node_modules/chardet": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
-      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.0.tgz",
+      "integrity": "sha512-bNFETTG/pM5ryzQ9Ad0lJOTa6HWD/YsScAR3EnCPZRPlQh77JocYktSHOUHelyhm8IARL+o4c4F1bP5KVOjiRA==",
       "license": "MIT"
     },
     "node_modules/chownr": {
@@ -6270,20 +6316,6 @@
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
-    },
-    "node_modules/external-editor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
-      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
-      "license": "MIT",
-      "dependencies": {
-        "chardet": "^0.7.0",
-        "iconv-lite": "^0.4.24",
-        "tmp": "^0.0.33"
-      },
-      "engines": {
-        "node": ">=4"
-      }
     },
     "node_modules/extsprintf": {
       "version": "1.3.0",
@@ -8416,16 +8448,16 @@
       }
     },
     "node_modules/morgan": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.0.tgz",
-      "integrity": "sha512-AbegBVI4sh6El+1gNwvD5YIck7nSA36weD7xvIxG4in80j/UoK8AEGaWnnz8v1GxonMCltmlNs5ZKbGvl9b1XQ==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.1.tgz",
+      "integrity": "sha512-223dMRJtI/l25dJKWpgij2cMtywuG/WiUKXdvwfbhGKBhy1puASqXwFzmWZ7+K73vUPoR7SS2Qz2cI/g9MKw0A==",
       "license": "MIT",
       "dependencies": {
         "basic-auth": "~2.0.1",
         "debug": "2.6.9",
         "depd": "~2.0.0",
         "on-finished": "~2.3.0",
-        "on-headers": "~1.0.2"
+        "on-headers": "~1.1.0"
       },
       "engines": {
         "node": ">= 0.8.0"
@@ -8838,9 +8870,9 @@
       }
     },
     "node_modules/on-headers": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
-      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
+      "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -8871,15 +8903,6 @@
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/own-keys": {
@@ -10361,18 +10384,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
-      }
-    },
-    "node_modules/tmp": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-      "license": "MIT",
-      "dependencies": {
-        "os-tmpdir": "~1.0.2"
-      },
-      "engines": {
-        "node": ">=0.6.0"
       }
     },
     "node_modules/to-array-buffer": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@aws-sdk/client-s3": "^3.657.0",
         "@aws-sdk/client-ses": "^3.515.0",
         "@inquirer/prompts": "^7.2.0",
-        "@pretendonetwork/grpc": "^2.2.1",
+        "@pretendonetwork/grpc": "^2.2.3",
         "bcrypt": "^5.0.0",
         "buffer-crc32": "^0.2.13",
         "colors": "^1.4.0",
@@ -2234,9 +2234,9 @@
       }
     },
     "node_modules/@pretendonetwork/grpc": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@pretendonetwork/grpc/-/grpc-2.2.1.tgz",
-      "integrity": "sha512-qj5RG8eTIqCk60VtCYLZSvXVyLdfIh5FIT/Dy7Lqka7nY6ToRqqBWgrAidcECkBUGSh+hbtO7FfsQmWrXCtqcw==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@pretendonetwork/grpc/-/grpc-2.2.3.tgz",
+      "integrity": "sha512-bTyUtFPT1/IwAWix9nkNZlmUUlG/k0F6YnARpNIceg9F6Mw1iHvGvMwvuX06PY9svnKDUeGdyR41rl/YUilfBQ==",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@bufbuild/protobuf": "^2.2.2",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@aws-sdk/client-s3": "^3.657.0",
     "@aws-sdk/client-ses": "^3.515.0",
     "@inquirer/prompts": "^7.2.0",
-    "@pretendonetwork/grpc": "^2.2.1",
+    "@pretendonetwork/grpc": "^2.2.3",
     "bcrypt": "^5.0.0",
     "buffer-crc32": "^0.2.13",
     "colors": "^1.4.0",

--- a/src/config-manager.ts
+++ b/src/config-manager.ts
@@ -92,6 +92,11 @@ export const config: Config = {
 		local_cdn: (process.env.PN_ACT_CONFIG_DOMAINS_LOCAL_CDN || '').split(','),
 		nasc: (process.env.PN_ACT_CONFIG_DOMAINS_NASC || 'nasc.pretendo.cc').split(','),
 		nnas: (process.env.PN_ACT_CONFIG_DOMAINS_NNAS || 'c.account.pretendo.cc,account.pretendo.cc').split(',')
+	},
+	discourse: {
+		forum_url: process.env.PN_ACT_CONFIG_DISCOURSE_FORUM_URL || '',
+		api_key: process.env.PN_ACT_CONFIG_DISCOURSE_API_KEY || '',
+		api_username: process.env.PN_ACT_CONFIG_DISCOURSE_API_USERNAME || ''
 	}
 };
 

--- a/src/config-manager.ts
+++ b/src/config-manager.ts
@@ -77,7 +77,12 @@ export const config: Config = {
 			account: process.env.PN_ACT_CONFIG_GRPC_MASTER_API_KEY_ACCOUNT || '',
 			api: process.env.PN_ACT_CONFIG_GRPC_MASTER_API_KEY_API || ''
 		},
-		port: Number(process.env.PN_ACT_CONFIG_GRPC_PORT || '')
+		port: Number(process.env.PN_ACT_CONFIG_GRPC_PORT || ''),
+		miiverse: {
+			host: process.env.PN_ACT_CONFIG_GRPC_MIIVERSE_HOST || '',
+			port: Number(process.env.PN_ACT_CONFIG_GRPC_MIIVERSE_PORT || ''),
+			api_key: process.env.PN_ACT_CONFIG_GRPC_MIIVERSE_KEY_API || ''
+		}
 	},
 	server_environment: process.env.PN_ACT_CONFIG_SERVER_ENVIRONMENT || '',
 	datastore: {

--- a/src/models/pnid.ts
+++ b/src/models/pnid.ts
@@ -242,6 +242,22 @@ PNIDSchema.method('scrub', async function scrub() {
 		}
 	}
 
+	if (config.discourse.forum_url && config.discourse.api_key && config.discourse.api_username) {
+		const response = await fetch(`${config.discourse.forum_url}/u/by-external/${this.pid}.json`);
+		const json = await response.json();
+
+		if (!json.errors && json.user) {
+			await fetch(`${config.discourse.forum_url}/admin/users/${json.user.id}/anonymize.json`, {
+				method: 'PUT',
+				headers: {
+					'content-type': 'application/json',
+					'Api-Key': config.discourse.api_key,
+					'Api-Username': config.discourse.api_username
+				}
+			});
+		}
+	}
+
 	await this.updateMii({
 		name: 'Default',
 		primary: 'Y',

--- a/src/models/pnid.ts
+++ b/src/models/pnid.ts
@@ -249,18 +249,22 @@ PNIDSchema.method('scrub', async function scrub() {
 	}
 
 	if (config.discourse.forum_url && config.discourse.api_key && config.discourse.api_username) {
-		const response = await fetch(`${config.discourse.forum_url}/u/by-external/${this.pid}.json`);
-		const json = await response.json();
+		try {
+			const response = await fetch(`${config.discourse.forum_url}/u/by-external/${this.pid}.json`);
+			const json = await response.json();
 
-		if (!json.errors && json.user) {
-			await fetch(`${config.discourse.forum_url}/admin/users/${json.user.id}/anonymize.json`, {
-				method: 'PUT',
-				headers: {
-					'content-type': 'application/json',
-					'Api-Key': config.discourse.api_key,
-					'Api-Username': config.discourse.api_username
-				}
-			});
+			if (!json.errors && json.user) {
+				await fetch(`${config.discourse.forum_url}/admin/users/${json.user.id}/anonymize.json`, {
+					method: 'PUT',
+					headers: {
+						'content-type': 'application/json',
+						'Api-Key': config.discourse.api_key,
+						'Api-Username': config.discourse.api_username
+					}
+				});
+			}
+		} catch (error) {
+			LOG_ERROR(`ERROR REMOVING ${this.username} FORUM DATA. ${error}`);
 		}
 	}
 

--- a/src/services/grpc/account/v2/delete-account.ts
+++ b/src/services/grpc/account/v2/delete-account.ts
@@ -1,0 +1,31 @@
+import { Status, ServerError } from 'nice-grpc';
+import { getPNIDByPID } from '@/database';
+import { sendPNIDDeletedEmail } from '@/util';
+import { LOG_ERROR } from '@/logger';
+import type { DeleteAccountRequest, DeleteAccountResponse } from '@pretendonetwork/grpc/account/v2/delete_account_rpc';
+
+export async function deleteAccount(request: DeleteAccountRequest): Promise<DeleteAccountResponse> {
+	const pnid = await getPNIDByPID(request.pid);
+
+	if (!pnid) {
+		throw new ServerError(
+			Status.INVALID_ARGUMENT,
+			'No PNID found'
+		);
+	}
+
+	try {
+		const email = pnid.email.address;
+
+		await pnid.scrub();
+		await pnid.save();
+
+		await sendPNIDDeletedEmail(email, pnid.username);
+	} catch (error) {
+		LOG_ERROR(`Deleting PNID ${error}`);
+	}
+
+	return {
+		hasDeleted: pnid.deleted
+	};
+}

--- a/src/services/grpc/account/v2/implementation.ts
+++ b/src/services/grpc/account/v2/implementation.ts
@@ -3,11 +3,13 @@ import { getNEXPassword } from '@/services/grpc/account/v2/get-nex-password';
 import { getNEXData } from '@/services/grpc/account/v2/get-nex-data';
 import { updatePNIDPermissions } from '@/services/grpc/account/v2/update-pnid-permissions';
 import { exchangeTokenForUserData } from '@/services/grpc/account/v2/exchange-token-for-user-data';
+import { deleteAccount } from '@/services/grpc/account/v2/delete-account';
 
 export const accountServiceImplementationV2 = {
 	getUserData,
 	getNEXPassword,
 	getNEXData,
 	updatePNIDPermissions,
-	exchangeTokenForUserData
+	exchangeTokenForUserData,
+	deleteAccount
 };

--- a/src/services/grpc/api/v2/delete-account.ts
+++ b/src/services/grpc/api/v2/delete-account.ts
@@ -1,0 +1,31 @@
+import { Status, ServerError } from 'nice-grpc';
+import { getPNIDByPID } from '@/database';
+import { sendPNIDDeletedEmail } from '@/util';
+import { LOG_ERROR } from '@/logger';
+import type { DeleteAccountRequest, DeleteAccountResponse } from '@pretendonetwork/grpc/api/v2/delete_account_rpc';
+
+export async function deleteAccount(request: DeleteAccountRequest): Promise<DeleteAccountResponse> {
+	const pnid = await getPNIDByPID(request.pid);
+
+	if (!pnid) {
+		throw new ServerError(
+			Status.INVALID_ARGUMENT,
+			'No PNID found'
+		);
+	}
+
+	try {
+		const email = pnid.email.address;
+
+		await pnid.scrub();
+		await pnid.save();
+
+		await sendPNIDDeletedEmail(email, pnid.username);
+	} catch (error) {
+		LOG_ERROR(`Deleting PNID ${error}`);
+	}
+
+	return {
+		hasDeleted: pnid.deleted
+	};
+}

--- a/src/services/grpc/api/v2/implementation.ts
+++ b/src/services/grpc/api/v2/implementation.ts
@@ -6,6 +6,7 @@ import { forgotPassword } from '@/services/grpc/api/v2/forgot-password';
 import { resetPassword } from '@/services/grpc/api/v2/reset-password';
 import { setDiscordConnectionData } from '@/services/grpc/api/v2/set-discord-connection-data';
 import { setStripeConnectionData } from '@/services/grpc/api/v2/set-stripe-connection-data';
+import { deleteAccount } from '@/services/grpc/api/v2/delete-account';
 
 export const apiServiceImplementationV2 = {
 	register,
@@ -15,5 +16,6 @@ export const apiServiceImplementationV2 = {
 	forgotPassword,
 	resetPassword,
 	setDiscordConnectionData,
-	setStripeConnectionData
+	setStripeConnectionData,
+	deleteAccount
 };

--- a/src/types/common/config.ts
+++ b/src/types/common/config.ts
@@ -53,6 +53,11 @@ export interface Config {
 			api: string;
 		};
 		port: number;
+		miiverse: {
+			host: string;
+			port: number;
+			api_key: string;
+		};
 	};
 	stripe?: {
 		secret_key: string;

--- a/src/types/common/config.ts
+++ b/src/types/common/config.ts
@@ -62,4 +62,9 @@ export interface Config {
 		signature_secret: string;
 	};
 	domains: Record<DomainService, string[]>;
+	discourse: {
+		forum_url: string;
+		api_key: string;
+		api_username: string;
+	};
 }


### PR DESCRIPTION
Resolves #XXX

### Changes:

Implements the account server portions of https://github.com/PretendoNetwork/grpc/pull/8:

- Updates `pnid.scrub` to fully delete the Stripe user automatically, if exists. This was previously done manually, with only the subscription being automatically deleted. Deleting the user will delete subscriptions though, so this is safe
- Updates `pnid.scrub` to anonymize forum user data automatically, if exists. This was previously done manually
- Updates `pnid.scrub` to remove Miiverse (Juxtaposition) user data automatically, if exists. This was previously done manually
- Adds `deleteAccount` methods to both the `account` and `api` gRPC endpoints
- Ran `npm audit fix` since there were a lot of outdated packages (there's still vulns being reported that couldn't be fixed automatically, but that's out of scope here)

Not fully tested since Juxtaposition lacks it's implementation of things. Individual parts, like the Discourse scrubbing, were tested in isolation however

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [x] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [ ] I have tested all of my changes.