### PR TITLE
Move certificate device ID check close to other certificate checks

### DIFF
--- a/src/middleware/console-status-verification.ts
+++ b/src/middleware/console-status-verification.ts
@@ -42,6 +42,21 @@ async function consoleStatusVerificationMiddleware(request: express.Request, res
 		return;
 	}
 
+	const certificateDeviceID = parseInt(request.certificate.certificateName.slice(2).split('-')[0], 16);
+
+	if (deviceID !== certificateDeviceID) {
+		// TODO - Change this to a different error
+		response.status(400).send(xmlbuilder.create({
+			error: {
+				cause: 'Bad Request',
+				code: '1600',
+				message: 'Unable to process request'
+			}
+		}).end());
+
+		return;
+	}
+
 	const serialNumber = getValueFromHeaders(request.headers, 'x-nintendo-serial-number');
 
 	// TODO - Verify serial numbers somehow?
@@ -110,21 +125,6 @@ async function consoleStatusVerificationMiddleware(request: express.Request, res
 	}
 
 	if (device.serial !== serialNumber) {
-		// TODO - Change this to a different error
-		response.status(400).send(xmlbuilder.create({
-			error: {
-				cause: 'Bad Request',
-				code: '1600',
-				message: 'Unable to process request'
-			}
-		}).end());
-
-		return;
-	}
-
-	const certificateDeviceID = parseInt(request.certificate.certificateName.slice(2).split('-')[0], 16);
-
-	if (deviceID !== certificateDeviceID) {
 		// TODO - Change this to a different error
 		response.status(400).send(xmlbuilder.create({
 			error: {


### PR DESCRIPTION
Resolves #XXX

### Changes:

Moves the check in `consoleStatusVerificationMiddleware` which verifies that `x-nintendo-device-id` matches the certificate to be closer to other certificate related checks

This also fixes a bug where a duplicate entry for a serial/device ID would get made in the database before this check. This couldn't be used as a bypass or anything, since this check would still stop requests, but the duped entry in the database can be unintuitive

Untested but it's just moving a check to a new line, should be fine

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [ ] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [ ] I have tested all of my changes.