### PR TITLE
Wrap all NNAS errors in an `errors` block

### DIFF
--- a/src/middleware/console-status-verification.ts
+++ b/src/middleware/console-status-verification.ts
@@ -7,9 +7,11 @@ import type express from 'express';
 async function consoleStatusVerificationMiddleware(request: express.Request, response: express.Response, next: express.NextFunction): Promise<void> {
 	if (!request.certificate || !request.certificate.valid) {
 		response.status(400).send(xmlbuilder.create({
-			error: {
-				code: '0110',
-				message: 'Unlinked device'
+			errors: {
+				error: {
+					code: '0110',
+					message: 'Unlinked device'
+				}
 			}
 		}).end());
 
@@ -20,9 +22,11 @@ async function consoleStatusVerificationMiddleware(request: express.Request, res
 
 	if (!deviceIDHeader) {
 		response.status(400).send(xmlbuilder.create({
-			error: {
-				code: '0002',
-				message: 'deviceId format is invalid'
+			errors: {
+				error: {
+					code: '0002',
+					message: 'deviceId format is invalid'
+				}
 			}
 		}).end());
 
@@ -33,9 +37,11 @@ async function consoleStatusVerificationMiddleware(request: express.Request, res
 
 	if (isNaN(deviceID)) {
 		response.status(400).send(xmlbuilder.create({
-			error: {
-				code: '0002',
-				message: 'deviceId format is invalid'
+			errors: {
+				error: {
+					code: '0002',
+					message: 'deviceId format is invalid'
+				}
 			}
 		}).end());
 
@@ -47,10 +53,12 @@ async function consoleStatusVerificationMiddleware(request: express.Request, res
 	if (deviceID !== certificateDeviceID) {
 		// TODO - Change this to a different error
 		response.status(400).send(xmlbuilder.create({
-			error: {
-				cause: 'Bad Request',
-				code: '1600',
-				message: 'Unable to process request'
+			errors: {
+				error: {
+					cause: 'Bad Request',
+					code: '1600',
+					message: 'Unable to process request'
+				}
 			}
 		}).end());
 
@@ -74,9 +82,11 @@ async function consoleStatusVerificationMiddleware(request: express.Request, res
 	// * compare against. We are not so lucky
 	if (!serialNumber) {
 		response.status(400).send(xmlbuilder.create({
-			error: {
-				code: '0002',
-				message: 'serialNumber format is invalid'
+			errors: {
+				error: {
+					code: '0002',
+					message: 'serialNumber format is invalid'
+				}
 			}
 		}).end());
 
@@ -96,9 +106,11 @@ async function consoleStatusVerificationMiddleware(request: express.Request, res
 		// * know that serial tampering happened on the 3DS if this fails
 		// * to find a device document.
 		response.status(400).send(xmlbuilder.create({
-			error: {
-				code: '0002',
-				message: 'serialNumber format is invalid'
+			errors: {
+				error: {
+					code: '0002',
+					message: 'serialNumber format is invalid'
+				}
 			}
 		}).end());
 
@@ -127,10 +139,12 @@ async function consoleStatusVerificationMiddleware(request: express.Request, res
 	if (device.serial !== serialNumber) {
 		// TODO - Change this to a different error
 		response.status(400).send(xmlbuilder.create({
-			error: {
-				cause: 'Bad Request',
-				code: '1600',
-				message: 'Unable to process request'
+			errors: {
+				error: {
+					cause: 'Bad Request',
+					code: '1600',
+					message: 'Unable to process request'
+				}
 			}
 		}).end());
 

--- a/src/services/nnas/routes/oauth.ts
+++ b/src/services/nnas/routes/oauth.ts
@@ -25,10 +25,12 @@ router.post('/access_token/generate', deviceCertificateMiddleware, consoleStatus
 
 	if (!['password', 'refresh_token'].includes(grantType)) {
 		response.status(400).send(xmlbuilder.create({
-			error: {
-				cause: 'grant_type',
-				code: '0004',
-				message: 'Invalid Grant Type'
+			errors: {
+				error: {
+					cause: 'grant_type',
+					code: '0004',
+					message: 'Invalid Grant Type'
+				}
 			}
 		}).end());
 
@@ -40,10 +42,12 @@ router.post('/access_token/generate', deviceCertificateMiddleware, consoleStatus
 	if (grantType === 'password') {
 		if (!username || username.trim() === '') {
 			response.status(400).send(xmlbuilder.create({
-				error: {
-					cause: 'user_id',
-					code: '0002',
-					message: 'user_id format is invalid'
+				errors: {
+					error: {
+						cause: 'user_id',
+						code: '0002',
+						message: 'user_id format is invalid'
+					}
 				}
 			}).end());
 
@@ -52,10 +56,12 @@ router.post('/access_token/generate', deviceCertificateMiddleware, consoleStatus
 
 		if (!password || password.trim() === '') {
 			response.status(400).send(xmlbuilder.create({
-				error: {
-					cause: 'password',
-					code: '0002',
-					message: 'password format is invalid'
+				errors: {
+					error: {
+						cause: 'password',
+						code: '0002',
+						message: 'password format is invalid'
+					}
 				}
 			}).end());
 
@@ -79,10 +85,12 @@ router.post('/access_token/generate', deviceCertificateMiddleware, consoleStatus
 	} else {
 		if (!refreshToken || refreshToken.trim() === '') {
 			response.status(400).send(xmlbuilder.create({
-				error: {
-					cause: 'refresh_token',
-					code: '0106',
-					message: 'Invalid Refresh Token'
+				errors: {
+					error: {
+						cause: 'refresh_token',
+						code: '0106',
+						message: 'Invalid Refresh Token'
+					}
 				}
 			}).end());
 
@@ -94,10 +102,12 @@ router.post('/access_token/generate', deviceCertificateMiddleware, consoleStatus
 
 			if (!pnid) {
 				response.status(400).send(xmlbuilder.create({
-					error: {
-						cause: 'refresh_token',
-						code: '0106',
-						message: 'Invalid Refresh Token'
+					errors: {
+						error: {
+							cause: 'refresh_token',
+							code: '0106',
+							message: 'Invalid Refresh Token'
+						}
 					}
 				}).end());
 
@@ -105,10 +115,12 @@ router.post('/access_token/generate', deviceCertificateMiddleware, consoleStatus
 			}
 		} catch {
 			response.status(400).send(xmlbuilder.create({
-				error: {
-					cause: 'refresh_token',
-					code: '0106',
-					message: 'Invalid Refresh Token'
+				errors: {
+					error: {
+						cause: 'refresh_token',
+						code: '0106',
+						message: 'Invalid Refresh Token'
+					}
 				}
 			}).end());
 
@@ -121,9 +133,11 @@ router.post('/access_token/generate', deviceCertificateMiddleware, consoleStatus
 		// * 0143 is the "The link to this Nintendo Network ID has been temporarliy removed" error,
 		// * maybe that is a better error to use here?
 		response.status(400).send(xmlbuilder.create({
-			error: {
-				code: '0112',
-				message: pnid.username
+			errors: {
+				error: {
+					code: '0112',
+					message: pnid.username
+				}
 			}
 		}).end());
 

--- a/src/services/nnas/routes/people.ts
+++ b/src/services/nnas/routes/people.ts
@@ -53,10 +53,12 @@ router.post('/', ratelimit, deviceCertificateMiddleware, async (request: express
 	if (!request.certificate || !request.certificate.valid) {
 		// TODO - Change this to a different error
 		response.status(400).send(xmlbuilder.create({
-			error: {
-				cause: 'Bad Request',
-				code: '1600',
-				message: 'Unable to process request'
+			errors: {
+				error: {
+					cause: 'Bad Request',
+					code: '1600',
+					message: 'Unable to process request'
+				}
 			}
 		}).end());
 
@@ -205,10 +207,12 @@ router.post('/', ratelimit, deviceCertificateMiddleware, async (request: express
 		await session.abortTransaction();
 
 		response.status(400).send(xmlbuilder.create({
-			error: {
-				cause: 'Bad Request',
-				code: '1600',
-				message: 'Unable to process request'
+			errors: {
+				error: {
+					cause: 'Bad Request',
+					code: '1600',
+					message: 'Unable to process request'
+				}
 			}
 		}).end());
 


### PR DESCRIPTION
Resolves #XXX

### Changes:

The NNAS client expects all errors to be in a "errors" block. This was not previously done, and a while ago the errors were updated to support this, but a few instances were missed. This likely fixes many 102-2402 errors, including those for when an account is being logged into when it was deleted off-device.

Untested but I verified that responses match those from the official servers, and this is already how \~50 of our other NNAS errors are handled. This just cleans up the stragglers.

This also lines up with this comment https://github.com/PretendoNetwork/account/issues/160#issuecomment-2798163288.

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [ ] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [ ] I have tested all of my changes.