### PR TITLE
Server provisioning

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -96,3 +96,4 @@ Configurations are loaded through environment variables. `.env` files are suppor
 | `PN_ACT_CONFIG_GRPC_MIIVERSE_HOST`            | Used to remove Miiverse user data during account deletion                                                       | No       |
 | `PN_ACT_CONFIG_GRPC_MIIVERSE_PORT`            | Used to remove Miiverse user data during account deletion                                                       | No       |
 | `PN_ACT_CONFIG_GRPC_MIIVERSE_KEY_API`         | Used to remove Miiverse user data during account deletion                                                       | No       |
+| `PN_ACT_PROVISIONING_SERVER_CONFIG`           | Specify a path to a JSON file containing a list of servers to provision automatically to the DB                 | Yes      |

--- a/src/config-manager.ts
+++ b/src/config-manager.ts
@@ -13,7 +13,8 @@ export const disabledFeatures = {
 	email: false,
 	captcha: false,
 	s3: false,
-	datastore: false
+	datastore: false,
+	serverProvisioning: false
 };
 
 const hexadecimalStringRegex = /^[0-9a-f]+$/i;
@@ -40,6 +41,9 @@ export const config: Config = {
 	mongoose: {
 		connection_string: process.env.PN_ACT_CONFIG_MONGO_CONNECTION_STRING || '',
 		options: mongooseConnectOptions
+	},
+	provisioning: {
+		server_config: process.env.PN_ACT_PROVISIONING_SERVER_CONFIG || ''
 	},
 	redis: {
 		client: {
@@ -280,6 +284,11 @@ if (!config.datastore.signature_secret) {
 		LOG_ERROR('Datastore signature secret key must be a 32-character hexadecimal string.');
 		configValid = false;
 	}
+}
+
+if (!config.provisioning.server_config) {
+	LOG_WARN('A server provisioning config file as not been set. Disabling feature, no server data will be provisioned. To enable feature set the PN_ACT_PROVISIONING_SERVER_CONFIG environment variable');
+	disabledFeatures.serverProvisioning = true;
 }
 
 if (!configValid) {

--- a/src/provisioning.ts
+++ b/src/provisioning.ts
@@ -1,0 +1,78 @@
+import fs from 'node:fs/promises';
+import { z } from 'zod';
+import mongoose from 'mongoose';
+import { config, disabledFeatures } from './config-manager';
+import { LOG_INFO, LOG_WARN } from './logger';
+import { Server } from './models/server';
+
+// Provisioning has a couple edgecases:
+// - It will only update existing entries, will not add new one
+// - Only the fields in the below schema will be updated
+
+const serverProvisioningSchema = z.object({
+	servers: z.array(z.object({
+		id: z.string(),
+		name: z.string(),
+		ip: z.string(),
+		port: z.coerce.number()
+	}))
+});
+
+async function readServerProvisioning(configPath: string): Promise<z.infer<typeof serverProvisioningSchema>> {
+	const fileContents = await fs.readFile(configPath, 'utf-8');
+	const parsedConfig = JSON.parse(fileContents);
+	return serverProvisioningSchema.parse(parsedConfig);
+}
+
+export async function handleServerProvisioning(): Promise<void> {
+	const serverData = await readServerProvisioning(config.provisioning.server_config).catch((err) => {
+		LOG_WARN('Failed to parse server provisioning config:');
+		console.error(err);
+	});
+	if (!serverData) {
+		return;
+	}
+
+	LOG_INFO('Starting server provisioning');
+	for (const server of serverData.servers) {
+		const id = new mongoose.Types.ObjectId(server.id);
+		const result = await Server.findOneAndUpdate({
+			id
+		}, {
+			$set: {
+				id,
+				service_name: server.name,
+				ip: server.ip,
+				port: server.port
+			}
+		});
+		if (!result) {
+			LOG_WARN(`Could not find existing server DB entry for ID ${server.id} - skipping provisioning`);
+		}
+	}
+}
+
+export function startProvisioner(): void {
+	if (disabledFeatures.serverProvisioning) {
+		return;
+	}
+
+	const runProvisioning = (): void => {
+		handleServerProvisioning().catch((err) => {
+			LOG_WARN('Failed to provision servers:');
+			console.error(err);
+		});
+	};
+
+	// Run once at boot
+	runProvisioning();
+
+	(async (): Promise<void> => {
+		const watcher = fs.watch(config.provisioning.server_config);
+		// eslint-disable-next-line @typescript-eslint/no-unused-vars -- Dont need this var
+		for await (const _ of watcher) {
+			LOG_INFO('Detected a change in the server provisioning config');
+			runProvisioning();
+		}
+	})();
+}

--- a/src/provisioning.ts
+++ b/src/provisioning.ts
@@ -36,11 +36,9 @@ export async function handleServerProvisioning(): Promise<void> {
 	LOG_INFO('Starting server provisioning');
 	for (const server of serverData.servers) {
 		const id = new mongoose.Types.ObjectId(server.id);
-		const result = await Server.findOneAndUpdate({
-			id
-		}, {
+		const result = await Server.findOneAndUpdate(id, {
 			$set: {
-				id,
+				_id: id,
 				service_name: server.name,
 				ip: server.ip,
 				port: server.port
@@ -50,6 +48,7 @@ export async function handleServerProvisioning(): Promise<void> {
 			LOG_WARN(`Could not find existing server DB entry for ID ${server.id} - skipping provisioning`);
 		}
 	}
+	LOG_INFO(`Finished provisioning ${serverData.servers.length} servers`);
 }
 
 export function startProvisioner(): void {

--- a/src/server.ts
+++ b/src/server.ts
@@ -16,6 +16,7 @@ import api from '@/services/api';
 import localcdn from '@/services/local-cdn';
 import assets from '@/services/assets';
 import { config, disabledFeatures } from '@/config-manager';
+import { startProvisioner } from './provisioning';
 
 process.title = 'Pretendo - Account';
 process.on('uncaughtException', (err, origin) => {
@@ -112,6 +113,8 @@ async function main(): Promise<void> {
 	LOG_SUCCESS('Cache enabled');
 	await startGRPCServer();
 	LOG_SUCCESS(`gRPC server started on port ${config.grpc.port}`);
+
+	startProvisioner();
 
 	app.listen(config.http.port, () => {
 		LOG_SUCCESS(`HTTP server started on port ${config.http.port}`);

--- a/src/types/common/config.ts
+++ b/src/types/common/config.ts
@@ -13,6 +13,9 @@ export interface Config {
 		connection_string: string;
 		options: mongoose.ConnectOptions;
 	};
+	provisioning: {
+		server_config: string;
+	};
 	redis: {
 		client: {
 			url: string;


### PR DESCRIPTION
Changes:
- Added configuration setting to specific a server provisioning file. It will be used on boot once and after detected file changes.
- Add provisioning system. It will update existing server DB entries and update them with info from the provisioning file.

I added this system so I don't have to manually update IPs and ports with every infra change. I've had to do it at least 20 times last week in infra work (and I made a lot of mistakes, causing downtime). With this PR, it can be fully automated (also less mistakes due to less manual work)
