### PR TITLE
Add basic health check before returning server address

### DIFF
--- a/src/models/server.ts
+++ b/src/models/server.ts
@@ -2,8 +2,8 @@ import dgram from 'node:dgram';
 import crypto from 'node:crypto';
 import { Schema, model } from 'mongoose';
 import uniqueValidator from 'mongoose-unique-validator';
-import type { IServer, IServerConnectInfo, IServerMethods, ServerModel } from '@/types/mongoose/server';
 import { LOG_WARN } from '@/logger';
+import type { IServer, IServerConnectInfo, IServerMethods, ServerModel } from '@/types/mongoose/server';
 
 // * Kinda ugly to slap this in with the Mongoose stuff but it's fine for now
 // TODO - Maybe move this one day?

--- a/src/models/server.ts
+++ b/src/models/server.ts
@@ -28,7 +28,7 @@ function healthCheck(target: { host: string; port: number }): Promise<string> {
 		const timeout = setTimeout(() => {
 			pendingHealthCheckRequests.delete(uuid);
 			reject(new Error('No valid response received'));
-		}, 5 * 1000); // TODO - Make this configurable? 5 seconds seems fine for now
+		}, 2 * 1000); // TODO - Make this configurable? 2 seconds seems fine for now
 
 		pendingHealthCheckRequests.set(uuid, () => {
 			clearTimeout(timeout);
@@ -96,7 +96,7 @@ ServerSchema.method('getServerConnectInfo', async function (): Promise<IServerCo
 	let target: string | undefined;
 
 	try {
-		// * Pick the first address that wins the health check. If no address responds in 5 seconds
+		// * Pick the first address that wins the health check. If no address responds in 2 seconds
 		// * nothing is returned
 		target = await Promise.race(healthCheckTargets.map(target => healthCheck(target)));
 	} catch {

--- a/src/models/server.ts
+++ b/src/models/server.ts
@@ -3,6 +3,7 @@ import crypto from 'node:crypto';
 import { Schema, model } from 'mongoose';
 import uniqueValidator from 'mongoose-unique-validator';
 import type { IServer, IServerConnectInfo, IServerMethods, ServerModel } from '@/types/mongoose/server';
+import { LOG_WARN } from '@/logger';
 
 // * Kinda ugly to slap this in with the Mongoose stuff but it's fine for now
 // TODO - Maybe move this one day?
@@ -101,6 +102,7 @@ ServerSchema.method('getServerConnectInfo', async function (): Promise<IServerCo
 	} catch {
 		// * Eat error for now, this means that no address responded in time
 		// TODO - Handle this
+		LOG_WARN(`Server ${this.service_name} faield to find healthy NEX server. Falling back to random IP`);
 	}
 
 	return {

--- a/src/provisioning.ts
+++ b/src/provisioning.ts
@@ -15,7 +15,8 @@ const serverProvisioningSchema = z.object({
 		name: z.string(),
 		ip: z.string().optional(),
 		ipList: z.array(z.string()).optional(),
-		port: z.coerce.number()
+		port: z.coerce.number(),
+		health_check_port: z.coerce.number().optional()
 	}))
 });
 
@@ -43,7 +44,8 @@ export async function handleServerProvisioning(): Promise<void> {
 				service_name: server.name,
 				ipList: server.ipList,
 				ip: server.ip,
-				port: server.port
+				port: server.port,
+				health_check_port: server.health_check_port
 			}
 		});
 		if (!result) {

--- a/src/types/mongoose/server.ts
+++ b/src/types/mongoose/server.ts
@@ -13,6 +13,7 @@ export interface IServer {
 	maintenance_mode: boolean;
 	device: number;
 	aes_key: string;
+	health_check_port: number;
 }
 
 export interface IServerConnectInfo {

--- a/src/types/mongoose/server.ts
+++ b/src/types/mongoose/server.ts
@@ -13,7 +13,7 @@ export interface IServer {
 	maintenance_mode: boolean;
 	device: number;
 	aes_key: string;
-	health_check_port: number;
+	health_check_port?: number;
 }
 
 export interface IServerConnectInfo {


### PR DESCRIPTION
Resolves #XXX

### Changes:

Adds a basic health check when requesting server information. Uses a simple race and whichever request returns first, wins. Falls back to a random IP if none return in time and just hopes for the best. I tested this with a local echo server and and a dedicated script and works as intended

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [ ] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [x] I have tested all of my changes.