### PR TITLE
Fix/provisioning updates

### DIFF
--- a/src/provisioning.ts
+++ b/src/provisioning.ts
@@ -8,15 +8,16 @@ import { Server } from './models/server';
 // Provisioning has a couple edgecases:
 // - It will only update existing entries, will not add new one
 // - Only the fields in the below schema will be updated
+// - Set fields to null to unset them. Undefined means it won't be modified
 
 const serverProvisioningSchema = z.object({
 	servers: z.array(z.object({
 		id: z.string(),
 		name: z.string(),
-		ip: z.string().optional(),
-		ipList: z.array(z.string()).optional(),
-		port: z.coerce.number(),
-		health_check_port: z.coerce.number().optional()
+		ip: z.string().nullable().optional(),
+		ip_list: z.array(z.string()).default([]),
+		port: z.number(),
+		health_check_port: z.number().nullable().optional()
 	}))
 });
 
@@ -42,7 +43,7 @@ export async function handleServerProvisioning(): Promise<void> {
 			$set: {
 				_id: id,
 				service_name: server.name,
-				ipList: server.ipList,
+				ip_list: server.ip_list,
 				ip: server.ip,
 				port: server.port,
 				health_check_port: server.health_check_port

--- a/src/provisioning.ts
+++ b/src/provisioning.ts
@@ -13,11 +13,12 @@ import { Server } from './models/server';
 const serverProvisioningSchema = z.object({
 	servers: z.array(z.object({
 		id: z.string(),
-		name: z.string(),
+		name: z.string().optional(),
 		ip: z.string().nullable().optional(),
-		ip_list: z.array(z.string()).default([]),
-		port: z.number(),
-		health_check_port: z.number().nullable().optional()
+		ip_list: z.array(z.string()).optional(),
+		port: z.number().optional(),
+		health_check_port: z.number().nullable().optional(),
+		aes_key: z.string().optional()
 	}))
 });
 
@@ -46,7 +47,8 @@ export async function handleServerProvisioning(): Promise<void> {
 				ip_list: server.ip_list,
 				ip: server.ip,
 				port: server.port,
-				health_check_port: server.health_check_port
+				health_check_port: server.health_check_port,
+				aes_key: server.aes_key
 			}
 		});
 		if (!result) {


### PR DESCRIPTION
Changes:
- Provisioning config: fixed support for ip_list, it had different naming convention
- Provisioning config: made nullable fields so they could be provisioned to null
- Provisioning config: added support for aes_key provisioning
- Provisioning config: made every field optional, so you don't have to provide every field in a config

Changes have been tested locally