### PR TITLE
Unescape timezone list in NNAS

### DIFF
--- a/src/services/nnas/timezones.json
+++ b/src/services/nnas/timezones.json
@@ -1983,7 +1983,7 @@
             {
                 "area": "America/Nassau",
                 "language": "en",
-                "name": "Eastern Time (US &amp; Canada)",
+                "name": "Eastern Time (US & Canada)",
                 "utc_offset": "-18000",
                 "order": "0"
             }
@@ -2171,14 +2171,14 @@
             {
                 "area": "America/Dawson",
                 "language": "en",
-                "name": "Pacific Time (US &amp; Canada)",
+                "name": "Pacific Time (US & Canada)",
                 "utc_offset": "-28800",
                 "order": "1"
             },
             {
                 "area": "America/Cambridge_Bay",
                 "language": "en",
-                "name": "Mountain Time (US &amp; Canada)",
+                "name": "Mountain Time (US & Canada)",
                 "utc_offset": "-25200",
                 "order": "2"
             },
@@ -2192,7 +2192,7 @@
             {
                 "area": "America/Rainy_River",
                 "language": "en",
-                "name": "Central Time (US &amp; Canada)",
+                "name": "Central Time (US & Canada)",
                 "utc_offset": "-21600",
                 "order": "4"
             },
@@ -2213,7 +2213,7 @@
             {
                 "area": "America/Iqaluit",
                 "language": "en",
-                "name": "Eastern Time (US &amp; Canada)",
+                "name": "Eastern Time (US & Canada)",
                 "utc_offset": "-18000",
                 "order": "7"
             },
@@ -5038,7 +5038,7 @@
             {
                 "area": "America/Grand_Turk",
                 "language": "en",
-                "name": "Eastern Time (US &amp; Canada)",
+                "name": "Eastern Time (US & Canada)",
                 "utc_offset": "-14400",
                 "order": "3"
             },
@@ -12519,7 +12519,7 @@
             {
                 "area": "America/Grand_Turk",
                 "language": "en",
-                "name": "Eastern Time (US &amp; Canada)",
+                "name": "Eastern Time (US & Canada)",
                 "utc_offset": "-14400",
                 "order": "0"
             }
@@ -13049,14 +13049,14 @@
             {
                 "area": "America/Los_Angeles",
                 "language": "en",
-                "name": "Pacific Time (US &amp; Canada)",
+                "name": "Pacific Time (US & Canada)",
                 "utc_offset": "-28800",
                 "order": "5"
             },
             {
                 "area": "America/Boise",
                 "language": "en",
-                "name": "Mountain Time (US &amp; Canada)",
+                "name": "Mountain Time (US & Canada)",
                 "utc_offset": "-25200",
                 "order": "6"
             },
@@ -13070,7 +13070,7 @@
             {
                 "area": "America/Chicago",
                 "language": "en",
-                "name": "Central Time (US &amp; Canada)",
+                "name": "Central Time (US & Canada)",
                 "utc_offset": "-21600",
                 "order": "8"
             },
@@ -13091,7 +13091,7 @@
             {
                 "area": "America/New_York",
                 "language": "en",
-                "name": "Eastern Time (US &amp; Canada)",
+                "name": "Eastern Time (US & Canada)",
                 "utc_offset": "-18000",
                 "order": "11"
             },


### PR DESCRIPTION
Resolves #325

### Changes:

Re-applies https://github.com/PretendoNetwork/account/commit/4db3be92a0ec565f4363f0f106b7dc630517f807. These changes were reverted in https://github.com/PretendoNetwork/account/commit/1a3445db5beec02ae521dcb6dc0430bc437a06b1 and I forgot to bring them back. This should fix the issue with people getting 022-2932 on the 3DS when creating an account. See https://github.com/PretendoNetwork/account/issues/325 for details, but TLDR is that the JSON file was already escaping certain characters which caused the server to do a "double escape", and the 3DS didn't like this

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [x] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [x] I have tested all of my changes.