### PR TITLE
fix: update mii renderer filenames and resolutions to match NNS

### DIFF
--- a/src/models/pnid.ts
+++ b/src/models/pnid.ts
@@ -235,7 +235,6 @@ PNIDSchema.method('generateMiiImages', async function generateMiiImages(): Promi
 	const miiStudioBodyUrl = mii.studioUrl({
 		type: 'all_body',
 		width: 270,
-		height: 360,
 		instanceCount: 1
 	});
 	const miiStudioBodyImageData = await got(miiStudioBodyUrl).buffer();

--- a/src/models/pnid.ts
+++ b/src/models/pnid.ts
@@ -214,7 +214,7 @@ PNIDSchema.method('generateMiiImages', async function generateMiiImages(): Promi
 	await uploadCDNAsset(config.s3.bucket, `${userMiiKey}/standard.tga`, tga, 'public-read');
 	await uploadCDNAsset(config.s3.bucket, `${userMiiKey}/normal_face.png`, miiStudioNormalFaceImageData, 'public-read');
 
-	const expressions: { expression: string; filename: string }[] = [
+	const expressions = [
 		{ expression: 'frustrated', filename: 'frustrated_face' },
 		{ expression: 'smile_open_mouth', filename: 'happy_face' },
 		{ expression: 'wink_left', filename: 'like_face' },

--- a/src/models/pnid.ts
+++ b/src/models/pnid.ts
@@ -202,7 +202,7 @@ PNIDSchema.method('generateMiiImages', async function generateMiiImages(): Promi
 	const mii = new Mii(Buffer.from(miiData, 'base64'));
 	const miiStudioUrl = mii.studioUrl({
 		type: 'face',
-		width: 128,
+		width: 96,
 		instanceCount: 1
 	});
 	const miiStudioNormalFaceImageData = await got(miiStudioUrl).buffer();
@@ -214,25 +214,32 @@ PNIDSchema.method('generateMiiImages', async function generateMiiImages(): Promi
 	await uploadCDNAsset(config.s3.bucket, `${userMiiKey}/standard.tga`, tga, 'public-read');
 	await uploadCDNAsset(config.s3.bucket, `${userMiiKey}/normal_face.png`, miiStudioNormalFaceImageData, 'public-read');
 
-	const expressions = ['frustrated', 'smile_open_mouth', 'wink_left', 'sorrow', 'surprise_open_mouth'];
-	for (const expression of expressions) {
+	const expressions: { expression: string; filename: string }[] = [
+		{ expression: 'frustrated', filename: 'frustrated_face' },
+		{ expression: 'smile_open_mouth', filename: 'happy_face' },
+		{ expression: 'wink_left', filename: 'like_face' },
+		{ expression: 'sorrow', filename: 'puzzled_face' },
+		{ expression: 'surprise_open_mouth', filename: 'surprised_face' }
+	];
+	for (const { expression, filename } of expressions) {
 		const miiStudioExpressionUrl = mii.studioUrl({
 			type: 'face',
 			expression: expression,
-			width: 128,
+			width: 96,
 			instanceCount: 1
 		});
 		const miiStudioExpressionImageData = await got(miiStudioExpressionUrl).buffer();
-		await uploadCDNAsset(config.s3.bucket, `${userMiiKey}/${expression}.png`, miiStudioExpressionImageData, 'public-read');
+		await uploadCDNAsset(config.s3.bucket, `${userMiiKey}/${filename}.png`, miiStudioExpressionImageData, 'public-read');
 	}
 
 	const miiStudioBodyUrl = mii.studioUrl({
 		type: 'all_body',
 		width: 270,
+		height: 360,
 		instanceCount: 1
 	});
 	const miiStudioBodyImageData = await got(miiStudioBodyUrl).buffer();
-	await uploadCDNAsset(config.s3.bucket, `${userMiiKey}/body.png`, miiStudioBodyImageData, 'public-read');
+	await uploadCDNAsset(config.s3.bucket, `${userMiiKey}/whole_body.png`, miiStudioBodyImageData, 'public-read');
 });
 
 PNIDSchema.method('markForDeletion', function markForDeletion() {

--- a/src/services/nnas/routes/miis.ts
+++ b/src/services/nnas/routes/miis.ts
@@ -65,21 +65,21 @@ router.get('/', async (request: express.Request, response: express.Response): Pr
 							type: 'standard'
 						},
 						{
-							cached_url: `${config.cdn.base_url}/mii/${pnid.pid}/frustrated.png`,
+							cached_url: `${config.cdn.base_url}/mii/${pnid.pid}/frustrated_face.png`,
 							id: pnid.mii.id,
-							url: `${config.cdn.base_url}/mii/${pnid.pid}/frustrated.png`,
+							url: `${config.cdn.base_url}/mii/${pnid.pid}/frustrated_face.png`,
 							type: 'frustrated_face'
 						},
 						{
-							cached_url: `${config.cdn.base_url}/mii/${pnid.pid}/smile_open_mouth.png`,
+							cached_url: `${config.cdn.base_url}/mii/${pnid.pid}/happy_face.png`,
 							id: pnid.mii.id,
-							url: `${config.cdn.base_url}/mii/${pnid.pid}/smile_open_mouth.png`,
+							url: `${config.cdn.base_url}/mii/${pnid.pid}/happy_face.png`,
 							type: 'happy_face'
 						},
 						{
-							cached_url: `${config.cdn.base_url}/mii/${pnid.pid}/wink_left.png`,
+							cached_url: `${config.cdn.base_url}/mii/${pnid.pid}/like_face.png`,
 							id: pnid.mii.id,
-							url: `${config.cdn.base_url}/mii/${pnid.pid}/wink_left.png`,
+							url: `${config.cdn.base_url}/mii/${pnid.pid}/like_face.png`,
 							type: 'like_face'
 						},
 						{
@@ -89,21 +89,21 @@ router.get('/', async (request: express.Request, response: express.Response): Pr
 							type: 'normal_face'
 						},
 						{
-							cached_url: `${config.cdn.base_url}/mii/${pnid.pid}/sorrow.png`,
+							cached_url: `${config.cdn.base_url}/mii/${pnid.pid}/puzzled_face.png`,
 							id: pnid.mii.id,
-							url: `${config.cdn.base_url}/mii/${pnid.pid}/sorrow.png`,
+							url: `${config.cdn.base_url}/mii/${pnid.pid}/puzzled_face.png`,
 							type: 'puzzled_face'
 						},
 						{
-							cached_url: `${config.cdn.base_url}/mii/${pnid.pid}/surprised_open_mouth.png`,
+							cached_url: `${config.cdn.base_url}/mii/${pnid.pid}/surprised_face.png`,
 							id: pnid.mii.id,
-							url: `${config.cdn.base_url}/mii/${pnid.pid}/surprised_open_mouth.png`,
+							url: `${config.cdn.base_url}/mii/${pnid.pid}/surprised_face.png`,
 							type: 'surprised_face'
 						},
 						{
-							cached_url: `${config.cdn.base_url}/mii/${pnid.pid}/body.png`,
+							cached_url: `${config.cdn.base_url}/mii/${pnid.pid}/whole_body.png`,
 							id: pnid.mii.id,
-							url: `${config.cdn.base_url}/mii/${pnid.pid}/body.png`,
+							url: `${config.cdn.base_url}/mii/${pnid.pid}/whole_body.png`,
 							type: 'whole_body'
 						}
 					]

--- a/src/types/mii-js.d.ts
+++ b/src/types/mii-js.d.ts
@@ -6,6 +6,7 @@ type MiiStudioURLOptions = {
 	type?: string;
 	expression?: string;
 	width?: number;
+	height?: number;
 	bgColor?: string;
 	clothesColor?: string;
 	cameraXRotate?: number;

--- a/src/types/mii-js.d.ts
+++ b/src/types/mii-js.d.ts
@@ -6,7 +6,6 @@ type MiiStudioURLOptions = {
 	type?: string;
 	expression?: string;
 	width?: number;
-	height?: number;
 	bgColor?: string;
 	clothesColor?: string;
 	cameraXRotate?: number;


### PR DESCRIPTION
Resolves #328 

### Changes:

 ### Summary

  Previously, the filenames used internal Mii Studio expression names (e.g.
  `smile_open_mouth.png`, `wink_left.png`) which do not match the filenames
  returned by the original NNS API. The face render resolution was also
  incorrect (128x128 instead of 96x96), and the whole body image was being
  rendered as a square (270x270) rather than the correct portrait resolution
  (270x360).

  ### Changes

  **Filenames:**
  | Old | New |
  |---|---|
  | `frustrated.png` | `frustrated_face.png` |
  | `smile_open_mouth.png` | `happy_face.png` |
  | `wink_left.png` | `like_face.png` |
  | `sorrow.png` | `puzzled_face.png` |
  | `surprise_open_mouth.png` | `surprised_face.png` |
  | `body.png` | `whole_body.png` |

  **Resolutions:**
  | Image | Old | New |
  |---|---|---|
  | face expressions | 128x128 | 96x96 |
  | whole body | 270x270 | 270x360 |

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [x] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [x] I have tested all of my changes.