### PR TITLE
Throw `0114` for users under 13

### DIFF
--- a/src/services/api/routes/v1/register.ts
+++ b/src/services/api/routes/v1/register.ts
@@ -118,6 +118,22 @@ router.post('/', async (request: express.Request, response: express.Response): P
 		}
 	}
 
+	if (age < 13) {
+		// * Wii U firmware 5.5.6 changed NNID setup to block setup of new accounts if the users age is
+		// * under 13, telling parents that they MUST call Nintendo to create the account, and we trusted
+		// * that users would be on these firmwares. Lower firmwares won't have this though, and will use
+		// * the old "COPPA approval" system
+		// *
+		// * Just block it all the time though, we don't want to deal with this headache
+		response.status(400).json({
+			app: 'api',
+			status: 400,
+			error: 'Must be 13 or older to use these services.'
+		});
+
+		return;
+	}
+
 	if (!email || email === '') {
 		response.status(400).json({
 			app: 'api',

--- a/src/services/nnas/routes/people.ts
+++ b/src/services/nnas/routes/people.ts
@@ -89,6 +89,25 @@ router.post('/', ratelimit, deviceCertificateMiddleware, async (request: express
 		}
 	}
 
+	if (age < 13) {
+		// * Wii U firmware 5.5.6 changed NNID setup to block setup of new accounts if the users age is
+		// * under 13, telling parents that they MUST call Nintendo to create the account, and we trusted
+		// * that users would be on these firmwares. Lower firmwares won't have this though, and will use
+		// * the old "COPPA approval" system
+		// *
+		// * Just block it all the time though, we don't want to deal with this headache
+		response.status(400).send(xmlbuilder.create({
+			errors: {
+				error: {
+					code: '0114',
+					message: 'COPPA approval is not complete'
+				}
+			}
+		}).end());
+
+		return;
+	}
+
 	const userExists = await doesPNIDExist(person.user_id);
 
 	if (userExists) {


### PR DESCRIPTION
Resolves #333 

### Changes:

Throws `0114` in NNAS (and equivalent in the API). This was missing because we trusted that the user would be on the latest firmware, in which Nintendo changed things with regard to COPPA and now require that users call Nintendo directly to create the account rather than using the old COPPA system. However older firmwares lack this, and we forgot to add it to the API in https://github.com/PretendoNetwork/account/pull/194 since we weren't accepting custom birthdays prior to that anyway, and custom/modded clients could bypass the client-side checks entirely anyway.

Rather than trying to implement the COPPA system, just block it all and call it a day. Too much of a headache

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [x] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [ ] I have tested all of my changes.