### PR TITLE
Fix automatic PNID scrubbing

### DIFF
--- a/src/database.ts
+++ b/src/database.ts
@@ -350,6 +350,10 @@ export async function checkMarkedDeletions(): Promise<void> {
 	});
 
 	for (const pnid of pnids) {
-		await pnid.scrub();
+		try {
+			await pnid.scrub();
+		} catch (error) {
+			LOG_ERROR(`Failed to scrub PNID ${pnid.pid}: ${error}`);
+		}
 	}
 }

--- a/src/models/pnid.ts
+++ b/src/models/pnid.ts
@@ -264,6 +264,8 @@ PNIDSchema.method('markForDeletion', async function markForDeletion() {
 			LOG_ERROR(`ERROR UPDATING SUBSCRIPTION FOR USER ${this.username} (${subscriptionID}). ${error}`);
 		}
 	}
+
+	await this.save();
 });
 
 PNIDSchema.method('scrub', async function scrub() {
@@ -362,6 +364,8 @@ PNIDSchema.method('scrub', async function scrub() {
 	this.connections.stripe.tier_level = 0;
 	this.connections.stripe.tier_name = '';
 	this.connections.stripe.latest_webhook_timestamp = 0;
+
+	await this.save();
 });
 
 PNIDSchema.method('hasPermission', function hasPermission(flag: PNIDPermissionFlag): boolean {

--- a/src/services/grpc/account/v2/delete-account.ts
+++ b/src/services/grpc/account/v2/delete-account.ts
@@ -24,8 +24,6 @@ export async function deleteAccount(request: DeleteAccountRequest): Promise<Dele
 			await pnid.markForDeletion();
 		}
 
-		await pnid.save();
-
 		await sendPNIDDeletedEmail(email, pnid.username);
 
 		if (request.bypassGracePeriod) {

--- a/src/services/grpc/api/v2/delete-account.ts
+++ b/src/services/grpc/api/v2/delete-account.ts
@@ -18,7 +18,6 @@ export async function deleteAccount(request: DeleteAccountRequest): Promise<Dele
 		const email = pnid.email.address;
 
 		await pnid.markForDeletion();
-		await pnid.save();
 
 		await sendPNIDDeletedEmail(email, pnid.username);
 	} catch (error) {

--- a/src/services/nnas/routes/people.ts
+++ b/src/services/nnas/routes/people.ts
@@ -581,7 +581,6 @@ router.post('/@me/deletion', async (request: express.Request, response: express.
 	const email = pnid.email.address;
 
 	await pnid.markForDeletion();
-	await pnid.save();
 
 	try {
 		await sendPNIDDeletedEmail(email, pnid.username);


### PR DESCRIPTION
Resolves #XXX

### Changes:

Removes the need to call `pnid.save()` during account deletions, this is now called internally. This also fixes a bug where the `checkMarkedDeletions` loop was not calling `pnid.save()` and thus automatic deletions were not being properly saved after the grace period was added (data like the forums and such was being deleted correctly, but the document data was not being saved).

Also adds a `try-catch` around the loop just to be safe.

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [ ] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [ ] I have tested all of my changes.