### PR TITLE
fix: extend NEX token duration to 24 hours

### DIFF
--- a/src/services/nasc/routes/ac.ts
+++ b/src/services/nasc/routes/ac.ts
@@ -88,7 +88,7 @@ async function processLoginRequest(server: HydratedServerDocument, pid: number, 
 			token_type: TokenType.NEX,
 			title_id: BigInt(parseInt(titleID, 16)),
 			issued: new Date(),
-			expires: new Date(Date.now() + (3600 * 1000))
+			expires: new Date(Date.now() + (24 * 3600 * 1000))
 		}
 	});
 

--- a/src/services/nnas/routes/provider.ts
+++ b/src/services/nnas/routes/provider.ts
@@ -234,7 +234,7 @@ router.get('/nex_token/@me', async (request: express.Request, response: express.
 			token_type: TokenType.NEX,
 			title_id: BigInt(parseInt(titleID, 16)),
 			issued: new Date(),
-			expires: new Date(Date.now() + (3600 * 1000))
+			expires: new Date(Date.now() + (24 * 3600 * 1000))
 		}
 	});
 


### PR DESCRIPTION
<!--

* Before making a pull request, ensure the changes are for an approved issue.
* If your changes are not for an approved issue, your pull request can and will be rejected.
*
* CHECK https://github.com/PretendoNetwork/REPO_NAME/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved
* FOR APPROVED ISSUES!

-->

Resolves #345 

### Changes:

This is intended to be a temporary fix for NEX tokens expiring until a more concrete solution can be made. This should resolve x01-0807, x06-0807, and the occasional 015-5016 that all usually result from a NEX token being expired. Changes were tested through verifying that expiration date is longer via MongoDB Compass

- [X] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [X] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [X] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [X] I have tested all of my changes.


Notes:

We should look into how Nintendo handled token expirations. They definitely had some way of handling it, as I could keep my 3DS on for weeks at a time without having to reboot it due to an expired token. Did they really just not let NEX tokens expire, or did they have some sort of way to make the console regenerate?