### PR TITLE
Update refresh token expiry to 7 days

### DIFF
--- a/src/services/api/routes/v1/login.ts
+++ b/src/services/api/routes/v1/login.ts
@@ -142,7 +142,7 @@ router.post('/', loginRatelimit, async (request: express.Request, response: expr
 				token_type: TokenType.OAuthRefresh,
 				title_id: BigInt(0),
 				issued: new Date(),
-				expires: new Date(Date.now() + 12 * 3600 * 1000)
+				expires: new Date(Date.now() + 7 * 24 * 3600 * 1000)
 			}
 		});
 

--- a/src/services/api/routes/v1/register.ts
+++ b/src/services/api/routes/v1/register.ts
@@ -465,7 +465,7 @@ router.post('/', webRegisterRatelimit, async (request: express.Request, response
 				token_type: TokenType.OAuthRefresh,
 				title_id: BigInt(0),
 				issued: new Date(),
-				expires: new Date(Date.now() + 12 * 3600 * 1000)
+				expires: new Date(Date.now() + 7 * 24 * 3600 * 1000)
 			}
 		});
 

--- a/src/services/grpc/api/v1/login.ts
+++ b/src/services/grpc/api/v1/login.ts
@@ -84,7 +84,7 @@ export async function login(request: LoginRequest): Promise<DeepPartial<LoginRes
 			token_type: TokenType.OAuthRefresh,
 			title_id: BigInt(0),
 			issued: new Date(),
-			expires: new Date(Date.now() + 12 * 3600 * 1000)
+			expires: new Date(Date.now() + 7 * 24 * 3600 * 1000)
 		}
 	});
 

--- a/src/services/grpc/api/v1/register.ts
+++ b/src/services/grpc/api/v1/register.ts
@@ -259,7 +259,7 @@ export async function register(request: RegisterRequest): Promise<DeepPartial<Lo
 			token_type: TokenType.OAuthRefresh,
 			title_id: BigInt(0),
 			issued: new Date(),
-			expires: new Date(Date.now() + 12 * 3600 * 1000)
+			expires: new Date(Date.now() + 7 * 24 * 3600 * 1000)
 		}
 	});
 

--- a/src/services/grpc/api/v2/login.ts
+++ b/src/services/grpc/api/v2/login.ts
@@ -84,7 +84,7 @@ export async function login(request: LoginRequest): Promise<DeepPartial<LoginRes
 			token_type: TokenType.OAuthRefresh,
 			title_id: BigInt(0),
 			issued: new Date(),
-			expires: new Date(Date.now() + 12 * 3600 * 1000)
+			expires: new Date(Date.now() + 7 * 24 * 3600 * 1000)
 		}
 	});
 

--- a/src/services/grpc/api/v2/register.ts
+++ b/src/services/grpc/api/v2/register.ts
@@ -259,7 +259,7 @@ export async function register(request: RegisterRequest): Promise<DeepPartial<Lo
 			token_type: TokenType.OAuthRefresh,
 			title_id: BigInt(0),
 			issued: new Date(),
-			expires: new Date(Date.now() + 12 * 3600 * 1000)
+			expires: new Date(Date.now() + 7 * 24 * 3600 * 1000)
 		}
 	});
 


### PR DESCRIPTION
Changes:
- Update refresh token expiry to 7 days (for web login)
